### PR TITLE
Use pytest style assertions in the test suite

### DIFF
--- a/tests/clients/test_requests/test_assertion_session.py
+++ b/tests/clients/test_requests/test_assertion_session.py
@@ -2,6 +2,8 @@ import time
 from unittest import TestCase
 from unittest import mock
 
+import pytest
+
 from authlib.integrations.requests_client import AssertionSession
 
 
@@ -20,7 +22,7 @@ class AssertionSessionTest(TestCase):
             resp = mock.MagicMock()
             resp.status_code = 200
             if r.url == "https://i.b/token":
-                self.assertIn("assertion=", r.body)
+                assert "assertion=" in r.body
                 resp.json = lambda: self.token
             return resp
 
@@ -63,4 +65,5 @@ class AssertionSessionTest(TestCase):
             audience="foo",
             key="secret",
         )
-        self.assertRaises(ValueError, sess.get, "https://i.b")
+        with pytest.raises(ValueError):
+            sess.get("https://i.b")

--- a/tests/clients/test_requests/test_oauth2_session.py
+++ b/tests/clients/test_requests/test_oauth2_session.py
@@ -3,6 +3,8 @@ from copy import deepcopy
 from unittest import TestCase
 from unittest import mock
 
+import pytest
+
 from authlib.common.security import generate_token
 from authlib.common.urls import add_params_to_uri
 from authlib.common.urls import url_encode
@@ -57,14 +59,15 @@ class OAuth2SessionTest(TestCase):
             "expires_at": int(time.time()) + 3600,
         }
         with OAuth2Session(self.client_id, token=token) as sess:
-            self.assertRaises(OAuthError, sess.get, "https://i.b")
+            with pytest.raises(OAuthError):
+                sess.get("https://i.b")
 
     def test_add_token_to_header(self):
         token = "Bearer " + self.token["access_token"]
 
         def verifier(r, **kwargs):
             auth_header = r.headers.get("Authorization", None)
-            self.assertEqual(auth_header, token)
+            assert auth_header == token
             resp = mock.MagicMock()
             return resp
 
@@ -74,7 +77,7 @@ class OAuth2SessionTest(TestCase):
 
     def test_add_token_to_body(self):
         def verifier(r, **kwargs):
-            self.assertIn(self.token["access_token"], r.body)
+            assert self.token["access_token"] in r.body
             resp = mock.MagicMock()
             return resp
 
@@ -86,7 +89,7 @@ class OAuth2SessionTest(TestCase):
 
     def test_add_token_to_uri(self):
         def verifier(r, **kwargs):
-            self.assertIn(self.token["access_token"], r.url)
+            assert self.token["access_token"] in r.url
             resp = mock.MagicMock()
             return resp
 
@@ -101,18 +104,18 @@ class OAuth2SessionTest(TestCase):
 
         sess = OAuth2Session(client_id=self.client_id)
         auth_url, state = sess.create_authorization_url(url)
-        self.assertIn(state, auth_url)
-        self.assertIn(self.client_id, auth_url)
-        self.assertIn("response_type=code", auth_url)
+        assert state in auth_url
+        assert self.client_id in auth_url
+        assert "response_type=code" in auth_url
 
         sess = OAuth2Session(client_id=self.client_id, prompt="none")
         auth_url, state = sess.create_authorization_url(
             url, state="foo", redirect_uri="https://i.b", scope="profile"
         )
-        self.assertEqual(state, "foo")
-        self.assertIn("i.b", auth_url)
-        self.assertIn("profile", auth_url)
-        self.assertIn("prompt=none", auth_url)
+        assert state == "foo"
+        assert "i.b" in auth_url
+        assert "profile" in auth_url
+        assert "prompt=none" in auth_url
 
     def test_code_challenge(self):
         sess = OAuth2Session(client_id=self.client_id, code_challenge_method="S256")
@@ -121,23 +124,23 @@ class OAuth2SessionTest(TestCase):
         auth_url, _ = sess.create_authorization_url(
             url, code_verifier=generate_token(48)
         )
-        self.assertIn("code_challenge", auth_url)
-        self.assertIn("code_challenge_method=S256", auth_url)
+        assert "code_challenge" in auth_url
+        assert "code_challenge_method=S256" in auth_url
 
     def test_token_from_fragment(self):
         sess = OAuth2Session(self.client_id)
         response_url = "https://i.b/callback#" + url_encode(self.token.items())
-        self.assertEqual(sess.token_from_fragment(response_url), self.token)
+        assert sess.token_from_fragment(response_url) == self.token
         token = sess.fetch_token(authorization_response=response_url)
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_fetch_token_post(self):
         url = "https://example.com/token"
 
         def fake_send(r, **kwargs):
-            self.assertIn("code=v", r.body)
-            self.assertIn("client_id=", r.body)
-            self.assertIn("grant_type=authorization_code", r.body)
+            assert "code=v" in r.body
+            assert "client_id=" in r.body
+            assert "grant_type=authorization_code" in r.body
             resp = mock.MagicMock()
             resp.status_code = 200
             resp.json = lambda: self.token
@@ -145,9 +148,9 @@ class OAuth2SessionTest(TestCase):
 
         sess = OAuth2Session(client_id=self.client_id)
         sess.send = fake_send
-        self.assertEqual(
-            sess.fetch_token(url, authorization_response="https://i.b/?code=v"),
-            self.token,
+        assert (
+            sess.fetch_token(url, authorization_response="https://i.b/?code=v")
+            == self.token
         )
 
         sess = OAuth2Session(
@@ -156,19 +159,20 @@ class OAuth2SessionTest(TestCase):
         )
         sess.send = fake_send
         token = sess.fetch_token(url, code="v")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
         error = {"error": "invalid_request"}
         sess = OAuth2Session(client_id=self.client_id, token=self.token)
         sess.send = mock_json_response(error)
-        self.assertRaises(OAuthError, sess.fetch_access_token, url)
+        with pytest.raises(OAuthError):
+            sess.fetch_access_token(url)
 
     def test_fetch_token_get(self):
         url = "https://example.com/token"
 
         def fake_send(r, **kwargs):
-            self.assertIn("code=v", r.url)
-            self.assertIn("grant_type=authorization_code", r.url)
+            assert "code=v" in r.url
+            assert "grant_type=authorization_code" in r.url
             resp = mock.MagicMock()
             resp.status_code = 200
             resp.json = lambda: self.token
@@ -179,7 +183,7 @@ class OAuth2SessionTest(TestCase):
         token = sess.fetch_token(
             url, authorization_response="https://i.b/?code=v", method="GET"
         )
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
         sess = OAuth2Session(
             client_id=self.client_id,
@@ -187,19 +191,19 @@ class OAuth2SessionTest(TestCase):
         )
         sess.send = fake_send
         token = sess.fetch_token(url, code="v", method="GET")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
         token = sess.fetch_token(url + "?q=a", code="v", method="GET")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_token_auth_method_client_secret_post(self):
         url = "https://example.com/token"
 
         def fake_send(r, **kwargs):
-            self.assertIn("code=v", r.body)
-            self.assertIn("client_id=", r.body)
-            self.assertIn("client_secret=bar", r.body)
-            self.assertIn("grant_type=authorization_code", r.body)
+            assert "code=v" in r.body
+            assert "client_id=" in r.body
+            assert "client_secret=bar" in r.body
+            assert "grant_type=authorization_code" in r.body
             resp = mock.MagicMock()
             resp.status_code = 200
             resp.json = lambda: self.token
@@ -212,13 +216,13 @@ class OAuth2SessionTest(TestCase):
         )
         sess.send = fake_send
         token = sess.fetch_token(url, code="v")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_access_token_response_hook(self):
         url = "https://example.com/token"
 
         def access_token_response_hook(resp):
-            self.assertEqual(resp.json(), self.token)
+            assert resp.json() == self.token
             return resp
 
         sess = OAuth2Session(client_id=self.client_id, token=self.token)
@@ -226,15 +230,15 @@ class OAuth2SessionTest(TestCase):
             "access_token_response", access_token_response_hook
         )
         sess.send = mock_json_response(self.token)
-        self.assertEqual(sess.fetch_token(url), self.token)
+        assert sess.fetch_token(url) == self.token
 
     def test_password_grant_type(self):
         url = "https://example.com/token"
 
         def fake_send(r, **kwargs):
-            self.assertIn("username=v", r.body)
-            self.assertIn("grant_type=password", r.body)
-            self.assertIn("scope=profile", r.body)
+            assert "username=v" in r.body
+            assert "grant_type=password" in r.body
+            assert "scope=profile" in r.body
             resp = mock.MagicMock()
             resp.status_code = 200
             resp.json = lambda: self.token
@@ -243,14 +247,14 @@ class OAuth2SessionTest(TestCase):
         sess = OAuth2Session(client_id=self.client_id, scope="profile")
         sess.send = fake_send
         token = sess.fetch_token(url, username="v", password="v")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_client_credentials_type(self):
         url = "https://example.com/token"
 
         def fake_send(r, **kwargs):
-            self.assertIn("grant_type=client_credentials", r.body)
-            self.assertIn("scope=profile", r.body)
+            assert "grant_type=client_credentials" in r.body
+            assert "scope=profile" in r.body
             resp = mock.MagicMock()
             resp.status_code = 200
             resp.json = lambda: self.token
@@ -263,7 +267,7 @@ class OAuth2SessionTest(TestCase):
         )
         sess.send = fake_send
         token = sess.fetch_token(url)
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_cleans_previous_token_before_fetching_new_one(self):
         """Makes sure the previous token is cleaned before fetching a new one.
@@ -281,64 +285,60 @@ class OAuth2SessionTest(TestCase):
         with mock.patch("time.time", lambda: now):
             sess = OAuth2Session(client_id=self.client_id, token=self.token)
             sess.send = mock_json_response(new_token)
-            self.assertEqual(sess.fetch_token(url), new_token)
+            assert sess.fetch_token(url) == new_token
 
     def test_mis_match_state(self):
         sess = OAuth2Session("foo")
-        self.assertRaises(
-            MismatchingStateException,
-            sess.fetch_token,
-            "https://i.b/token",
-            authorization_response="https://i.b/no-state?code=abc",
-            state="somestate",
-        )
+        with pytest.raises(MismatchingStateException):
+            sess.fetch_token(
+                "https://i.b/token",
+                authorization_response="https://i.b/no-state?code=abc",
+                state="somestate",
+            )
 
     def test_token_status(self):
         token = dict(access_token="a", token_type="bearer", expires_at=100)
         sess = OAuth2Session("foo", token=token)
 
-        self.assertTrue(sess.token.is_expired)
+        assert sess.token.is_expired
 
     def test_token_status2(self):
         token = dict(access_token="a", token_type="bearer", expires_in=10)
         sess = OAuth2Session("foo", token=token, leeway=15)
 
-        self.assertTrue(sess.token.is_expired(sess.leeway))
+        assert sess.token.is_expired(sess.leeway)
 
     def test_token_status3(self):
         token = dict(access_token="a", token_type="bearer", expires_in=10)
         sess = OAuth2Session("foo", token=token, leeway=5)
 
-        self.assertFalse(sess.token.is_expired(sess.leeway))
+        assert not sess.token.is_expired(sess.leeway)
 
     def test_token_expired(self):
         token = dict(access_token="a", token_type="bearer", expires_at=100)
         sess = OAuth2Session("foo", token=token)
-        self.assertRaises(
-            OAuthError,
-            sess.get,
-            "https://i.b/token",
-        )
+        with pytest.raises(OAuthError):
+            sess.get(
+                "https://i.b/token",
+            )
 
     def test_missing_token(self):
         sess = OAuth2Session("foo")
-        self.assertRaises(
-            OAuthError,
-            sess.get,
-            "https://i.b/token",
-        )
+        with pytest.raises(OAuthError):
+            sess.get(
+                "https://i.b/token",
+            )
 
     def test_register_compliance_hook(self):
         sess = OAuth2Session("foo")
-        self.assertRaises(
-            ValueError,
-            sess.register_compliance_hook,
-            "invalid_hook",
-            lambda o: o,
-        )
+        with pytest.raises(ValueError):
+            sess.register_compliance_hook(
+                "invalid_hook",
+                lambda o: o,
+            )
 
         def protected_request(url, headers, data):
-            self.assertIn("Authorization", headers)
+            assert "Authorization" in headers
             return url, headers, data
 
         sess = OAuth2Session("foo", token=self.token)
@@ -351,8 +351,8 @@ class OAuth2SessionTest(TestCase):
 
     def test_auto_refresh_token(self):
         def _update_token(token, refresh_token=None, access_token=None):
-            self.assertEqual(refresh_token, "b")
-            self.assertEqual(token, self.token)
+            assert refresh_token == "b"
+            assert token == self.token
 
         update_token = mock.Mock(side_effect=_update_token)
         old_token = dict(
@@ -366,12 +366,12 @@ class OAuth2SessionTest(TestCase):
         )
         sess.send = mock_json_response(self.token)
         sess.get("https://i.b/user")
-        self.assertTrue(update_token.called)
+        assert update_token.called
 
     def test_auto_refresh_token2(self):
         def _update_token(token, refresh_token=None, access_token=None):
-            self.assertEqual(access_token, "a")
-            self.assertEqual(token, self.token)
+            assert access_token == "a"
+            assert token == self.token
 
         update_token = mock.Mock(side_effect=_update_token)
         old_token = dict(access_token="a", token_type="bearer", expires_at=100)
@@ -384,7 +384,7 @@ class OAuth2SessionTest(TestCase):
         )
         sess.send = mock_json_response(self.token)
         sess.get("https://i.b/user")
-        self.assertFalse(update_token.called)
+        assert not update_token.called
 
         sess = OAuth2Session(
             "foo",
@@ -395,21 +395,21 @@ class OAuth2SessionTest(TestCase):
         )
         sess.send = mock_json_response(self.token)
         sess.get("https://i.b/user")
-        self.assertTrue(update_token.called)
+        assert update_token.called
 
     def test_revoke_token(self):
         sess = OAuth2Session("a")
         answer = {"status": "ok"}
         sess.send = mock_json_response(answer)
         resp = sess.revoke_token("https://i.b/token", "hi")
-        self.assertEqual(resp.json(), answer)
+        assert resp.json() == answer
         resp = sess.revoke_token(
             "https://i.b/token", "hi", token_type_hint="access_token"
         )
-        self.assertEqual(resp.json(), answer)
+        assert resp.json() == answer
 
         def revoke_token_request(url, headers, data):
-            self.assertEqual(url, "https://i.b/token")
+            assert url == "https://i.b/token"
             return url, headers, data
 
         sess.register_compliance_hook(
@@ -435,7 +435,7 @@ class OAuth2SessionTest(TestCase):
         }
         sess.send = mock_json_response(answer)
         resp = sess.introspect_token("https://i.b/token", "hi")
-        self.assertEqual(resp.json(), answer)
+        assert resp.json() == answer
 
     def test_client_secret_jwt(self):
         sess = OAuth2Session(
@@ -445,7 +445,7 @@ class OAuth2SessionTest(TestCase):
 
         mock_assertion_response(self, sess)
         token = sess.fetch_token("https://i.b/token")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_client_secret_jwt2(self):
         sess = OAuth2Session(
@@ -455,7 +455,7 @@ class OAuth2SessionTest(TestCase):
         )
         mock_assertion_response(self, sess)
         token = sess.fetch_token("https://i.b/token")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_private_key_jwt(self):
         client_secret = read_key_file("rsa_private.pem")
@@ -465,7 +465,7 @@ class OAuth2SessionTest(TestCase):
         sess.register_client_auth_method(PrivateKeyJWT())
         mock_assertion_response(self, sess)
         token = sess.fetch_token("https://i.b/token")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_custom_client_auth_method(self):
         def auth_client(client, method, uri, headers, body):
@@ -486,8 +486,8 @@ class OAuth2SessionTest(TestCase):
         sess.register_client_auth_method(("client_secret_uri", auth_client))
 
         def fake_send(r, **kwargs):
-            self.assertIn("client_id=", r.url)
-            self.assertIn("client_secret=", r.url)
+            assert "client_id=" in r.url
+            assert "client_secret=" in r.url
             resp = mock.MagicMock()
             resp.status_code = 200
             resp.json = lambda: self.token
@@ -495,7 +495,7 @@ class OAuth2SessionTest(TestCase):
 
         sess.send = fake_send
         token = sess.fetch_token("https://i.b/token")
-        self.assertEqual(token, self.token)
+        assert token == self.token
 
     def test_use_client_token_auth(self):
         import requests
@@ -504,7 +504,7 @@ class OAuth2SessionTest(TestCase):
 
         def verifier(r, **kwargs):
             auth_header = r.headers.get("Authorization", None)
-            self.assertEqual(auth_header, token)
+            assert auth_header == token
             resp = mock.MagicMock()
             return resp
 
@@ -519,7 +519,7 @@ class OAuth2SessionTest(TestCase):
 
         def verifier(r, **kwargs):
             timeout = kwargs.get("timeout")
-            self.assertEqual(timeout, expected_timeout)
+            assert timeout == expected_timeout
             resp = mock.MagicMock()
             return resp
 
@@ -538,7 +538,7 @@ class OAuth2SessionTest(TestCase):
 
         def verifier(r, **kwargs):
             timeout = kwargs.get("timeout")
-            self.assertEqual(timeout, expected_timeout)
+            assert timeout == expected_timeout
             resp = mock.MagicMock()
             return resp
 

--- a/tests/core/test_oauth2/test_rfc7523.py
+++ b/tests/core/test_oauth2/test_rfc7523.py
@@ -12,46 +12,44 @@ class ClientSecretJWTTest(TestCase):
     def test_nothing_set(self):
         jwt_signer = ClientSecretJWT()
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "HS256")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "HS256"
 
     def test_endpoint_set(self):
         jwt_signer = ClientSecretJWT(
             token_endpoint="https://example.com/oauth/access_token"
         )
 
-        self.assertEqual(
-            jwt_signer.token_endpoint, "https://example.com/oauth/access_token"
-        )
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "HS256")
+        assert jwt_signer.token_endpoint == "https://example.com/oauth/access_token"
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "HS256"
 
     def test_alg_set(self):
         jwt_signer = ClientSecretJWT(alg="HS512")
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "HS512")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "HS512"
 
     def test_claims_set(self):
         jwt_signer = ClientSecretJWT(claims={"foo1": "bar1"})
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, {"foo1": "bar1"})
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "HS256")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims == {"foo1": "bar1"}
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "HS256"
 
     def test_headers_set(self):
         jwt_signer = ClientSecretJWT(headers={"foo1": "bar1"})
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, {"foo1": "bar1"})
-        self.assertEqual(jwt_signer.alg, "HS256")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers == {"foo1": "bar1"}
+        assert jwt_signer.alg == "HS256"
 
     def test_all_set(self):
         jwt_signer = ClientSecretJWT(
@@ -61,12 +59,10 @@ class ClientSecretJWTTest(TestCase):
             alg="HS512",
         )
 
-        self.assertEqual(
-            jwt_signer.token_endpoint, "https://example.com/oauth/access_token"
-        )
-        self.assertEqual(jwt_signer.claims, {"foo1a": "bar1a"})
-        self.assertEqual(jwt_signer.headers, {"foo1b": "bar1b"})
-        self.assertEqual(jwt_signer.alg, "HS512")
+        assert jwt_signer.token_endpoint == "https://example.com/oauth/access_token"
+        assert jwt_signer.claims == {"foo1a": "bar1a"}
+        assert jwt_signer.headers == {"foo1b": "bar1b"}
+        assert jwt_signer.alg == "HS512"
 
     @staticmethod
     def sign_and_decode(jwt_signer, client_id, client_secret, token_endpoint):
@@ -97,21 +93,18 @@ class ClientSecretJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-            decoded,
-        )
+        assert {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        } == decoded
 
-        self.assertEqual({"alg": "HS256", "typ": "JWT"}, decoded.header)
+        assert {"alg": "HS256", "typ": "JWT"} == decoded.header
 
     def test_sign_custom_jti(self):
         jwt_signer = ClientSecretJWT(claims={"jti": "custom_jti"})
@@ -123,21 +116,17 @@ class ClientSecretJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertEqual("custom_jti", jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert "custom_jti" == jti
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-        )
-
-        self.assertEqual({"alg": "HS256", "typ": "JWT"}, decoded.header)
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        }
+        assert {"alg": "HS256", "typ": "JWT"} == decoded.header
 
     def test_sign_with_additional_header(self):
         jwt_signer = ClientSecretJWT(headers={"kid": "custom_kid"})
@@ -149,23 +138,17 @@ class ClientSecretJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-        )
-
-        self.assertEqual(
-            {"alg": "HS256", "typ": "JWT", "kid": "custom_kid"}, decoded.header
-        )
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        }
+        assert {"alg": "HS256", "typ": "JWT", "kid": "custom_kid"} == decoded.header
 
     def test_sign_with_additional_headers(self):
         jwt_signer = ClientSecretJWT(
@@ -179,29 +162,22 @@ class ClientSecretJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-        )
-
-        self.assertEqual(
-            {
-                "alg": "HS256",
-                "typ": "JWT",
-                "kid": "custom_kid",
-                "jku": "https://example.com/oauth/jwks",
-            },
-            decoded.header,
-        )
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        }
+        assert {
+            "alg": "HS256",
+            "typ": "JWT",
+            "kid": "custom_kid",
+            "jku": "https://example.com/oauth/jwks",
+        } == decoded.header
 
     def test_sign_with_additional_claim(self):
         jwt_signer = ClientSecretJWT(claims={"name": "Foo"})
@@ -213,22 +189,18 @@ class ClientSecretJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-                "name": "Foo",
-            },
-        )
-
-        self.assertEqual({"alg": "HS256", "typ": "JWT"}, decoded.header)
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+            "name": "Foo",
+        }
+        assert {"alg": "HS256", "typ": "JWT"} == decoded.header
 
     def test_sign_with_additional_claims(self):
         jwt_signer = ClientSecretJWT(claims={"name": "Foo", "role": "bar"})
@@ -240,23 +212,19 @@ class ClientSecretJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-                "name": "Foo",
-                "role": "bar",
-            },
-        )
-
-        self.assertEqual({"alg": "HS256", "typ": "JWT"}, decoded.header)
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+            "name": "Foo",
+            "role": "bar",
+        }
+        assert {"alg": "HS256", "typ": "JWT"} == decoded.header
 
 
 class PrivateKeyJWTTest(TestCase):
@@ -268,46 +236,44 @@ class PrivateKeyJWTTest(TestCase):
     def test_nothing_set(self):
         jwt_signer = PrivateKeyJWT()
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "RS256")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "RS256"
 
     def test_endpoint_set(self):
         jwt_signer = PrivateKeyJWT(
             token_endpoint="https://example.com/oauth/access_token"
         )
 
-        self.assertEqual(
-            jwt_signer.token_endpoint, "https://example.com/oauth/access_token"
-        )
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "RS256")
+        assert jwt_signer.token_endpoint == "https://example.com/oauth/access_token"
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "RS256"
 
     def test_alg_set(self):
         jwt_signer = PrivateKeyJWT(alg="RS512")
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "RS512")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "RS512"
 
     def test_claims_set(self):
         jwt_signer = PrivateKeyJWT(claims={"foo1": "bar1"})
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, {"foo1": "bar1"})
-        self.assertEqual(jwt_signer.headers, None)
-        self.assertEqual(jwt_signer.alg, "RS256")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims == {"foo1": "bar1"}
+        assert jwt_signer.headers is None
+        assert jwt_signer.alg == "RS256"
 
     def test_headers_set(self):
         jwt_signer = PrivateKeyJWT(headers={"foo1": "bar1"})
 
-        self.assertEqual(jwt_signer.token_endpoint, None)
-        self.assertEqual(jwt_signer.claims, None)
-        self.assertEqual(jwt_signer.headers, {"foo1": "bar1"})
-        self.assertEqual(jwt_signer.alg, "RS256")
+        assert jwt_signer.token_endpoint is None
+        assert jwt_signer.claims is None
+        assert jwt_signer.headers == {"foo1": "bar1"}
+        assert jwt_signer.alg == "RS256"
 
     def test_all_set(self):
         jwt_signer = PrivateKeyJWT(
@@ -317,12 +283,10 @@ class PrivateKeyJWTTest(TestCase):
             alg="RS512",
         )
 
-        self.assertEqual(
-            jwt_signer.token_endpoint, "https://example.com/oauth/access_token"
-        )
-        self.assertEqual(jwt_signer.claims, {"foo1a": "bar1a"})
-        self.assertEqual(jwt_signer.headers, {"foo1b": "bar1b"})
-        self.assertEqual(jwt_signer.alg, "RS512")
+        assert jwt_signer.token_endpoint == "https://example.com/oauth/access_token"
+        assert jwt_signer.claims == {"foo1a": "bar1a"}
+        assert jwt_signer.headers == {"foo1b": "bar1b"}
+        assert jwt_signer.alg == "RS512"
 
     @staticmethod
     def sign_and_decode(jwt_signer, client_id, public_key, private_key, token_endpoint):
@@ -354,21 +318,17 @@ class PrivateKeyJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-            decoded,
-        )
-
-        self.assertEqual({"alg": "RS256", "typ": "JWT"}, decoded.header)
+        assert {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        } == decoded
+        assert {"alg": "RS256", "typ": "JWT"} == decoded.header
 
     def test_sign_custom_jti(self):
         jwt_signer = PrivateKeyJWT(claims={"jti": "custom_jti"})
@@ -381,21 +341,17 @@ class PrivateKeyJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertEqual("custom_jti", jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert "custom_jti" == jti
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-        )
-
-        self.assertEqual({"alg": "RS256", "typ": "JWT"}, decoded.header)
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        }
+        assert {"alg": "RS256", "typ": "JWT"} == decoded.header
 
     def test_sign_with_additional_header(self):
         jwt_signer = PrivateKeyJWT(headers={"kid": "custom_kid"})
@@ -408,23 +364,17 @@ class PrivateKeyJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-        )
-
-        self.assertEqual(
-            {"alg": "RS256", "typ": "JWT", "kid": "custom_kid"}, decoded.header
-        )
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        }
+        assert {"alg": "RS256", "typ": "JWT", "kid": "custom_kid"} == decoded.header
 
     def test_sign_with_additional_headers(self):
         jwt_signer = PrivateKeyJWT(
@@ -439,29 +389,22 @@ class PrivateKeyJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-            },
-        )
-
-        self.assertEqual(
-            {
-                "alg": "RS256",
-                "typ": "JWT",
-                "kid": "custom_kid",
-                "jku": "https://example.com/oauth/jwks",
-            },
-            decoded.header,
-        )
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+        }
+        assert {
+            "alg": "RS256",
+            "typ": "JWT",
+            "kid": "custom_kid",
+            "jku": "https://example.com/oauth/jwks",
+        } == decoded.header
 
     def test_sign_with_additional_claim(self):
         jwt_signer = PrivateKeyJWT(claims={"name": "Foo"})
@@ -474,22 +417,18 @@ class PrivateKeyJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-                "name": "Foo",
-            },
-        )
-
-        self.assertEqual({"alg": "RS256", "typ": "JWT"}, decoded.header)
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+            "name": "Foo",
+        }
+        assert {"alg": "RS256", "typ": "JWT"} == decoded.header
 
     def test_sign_with_additional_claims(self):
         jwt_signer = PrivateKeyJWT(claims={"name": "Foo", "role": "bar"})
@@ -502,20 +441,16 @@ class PrivateKeyJWTTest(TestCase):
             "https://example.com/oauth/access_token",
         )
 
-        self.assertGreaterEqual(iat, pre_sign_time)
-        self.assertGreaterEqual(exp, iat + 3600)
-        self.assertLessEqual(exp, iat + 3600 + 2)
-        self.assertIsNotNone(jti)
+        assert iat >= pre_sign_time
+        assert exp >= iat + 3600
+        assert exp <= iat + 3600 + 2
+        assert jti is not None
 
-        self.assertEqual(
-            decoded,
-            {
-                "iss": "client_id_1",
-                "aud": "https://example.com/oauth/access_token",
-                "sub": "client_id_1",
-                "name": "Foo",
-                "role": "bar",
-            },
-        )
-
-        self.assertEqual({"alg": "RS256", "typ": "JWT"}, decoded.header)
+        assert decoded == {
+            "iss": "client_id_1",
+            "aud": "https://example.com/oauth/access_token",
+            "sub": "client_id_1",
+            "name": "Foo",
+            "role": "bar",
+        }
+        assert {"alg": "RS256", "typ": "JWT"} == decoded.header

--- a/tests/core/test_oauth2/test_rfc7591.py
+++ b/tests/core/test_oauth2/test_rfc7591.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import pytest
+
 from authlib.jose.errors import InvalidClaimError
 from authlib.oauth2.rfc7591 import ClientMetadataClaims
 
@@ -7,24 +9,30 @@ from authlib.oauth2.rfc7591 import ClientMetadataClaims
 class ClientMetadataClaimsTest(TestCase):
     def test_validate_redirect_uris(self):
         claims = ClientMetadataClaims({"redirect_uris": ["foo"]}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_validate_client_uri(self):
         claims = ClientMetadataClaims({"client_uri": "foo"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_validate_logo_uri(self):
         claims = ClientMetadataClaims({"logo_uri": "foo"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_validate_tos_uri(self):
         claims = ClientMetadataClaims({"tos_uri": "foo"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_validate_policy_uri(self):
         claims = ClientMetadataClaims({"policy_uri": "foo"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_validate_jwks_uri(self):
         claims = ClientMetadataClaims({"jwks_uri": "foo"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()

--- a/tests/core/test_oauth2/test_rfc7662.py
+++ b/tests/core/test_oauth2/test_rfc7662.py
@@ -1,56 +1,59 @@
 import unittest
 
+import pytest
+
 from authlib.oauth2.rfc7662 import IntrospectionToken
 
 
 class IntrospectionTokenTest(unittest.TestCase):
     def test_client_id(self):
         token = IntrospectionToken()
-        self.assertIsNone(token.client_id)
-        self.assertIsNone(token.get_client_id())
+        assert token.client_id is None
+        assert token.get_client_id() is None
 
         token = IntrospectionToken({"client_id": "foo"})
-        self.assertEqual(token.client_id, "foo")
-        self.assertEqual(token.get_client_id(), "foo")
+        assert token.client_id == "foo"
+        assert token.get_client_id() == "foo"
 
     def test_scope(self):
         token = IntrospectionToken()
-        self.assertIsNone(token.scope)
-        self.assertIsNone(token.get_scope())
+        assert token.scope is None
+        assert token.get_scope() is None
 
         token = IntrospectionToken({"scope": "foo"})
-        self.assertEqual(token.scope, "foo")
-        self.assertEqual(token.get_scope(), "foo")
+        assert token.scope == "foo"
+        assert token.get_scope() == "foo"
 
     def test_expires_in(self):
         token = IntrospectionToken()
-        self.assertEqual(token.get_expires_in(), 0)
+        assert token.get_expires_in() == 0
 
     def test_expires_at(self):
         token = IntrospectionToken()
-        self.assertIsNone(token.exp)
-        self.assertEqual(token.get_expires_at(), 0)
+        assert token.exp is None
+        assert token.get_expires_at() == 0
 
         token = IntrospectionToken({"exp": 3600})
-        self.assertEqual(token.exp, 3600)
-        self.assertEqual(token.get_expires_at(), 3600)
+        assert token.exp == 3600
+        assert token.get_expires_at() == 3600
 
     def test_all_attributes(self):
         # https://tools.ietf.org/html/rfc7662#section-2.2
         token = IntrospectionToken()
-        self.assertIsNone(token.active)
-        self.assertIsNone(token.scope)
-        self.assertIsNone(token.client_id)
-        self.assertIsNone(token.username)
-        self.assertIsNone(token.token_type)
-        self.assertIsNone(token.exp)
-        self.assertIsNone(token.iat)
-        self.assertIsNone(token.nbf)
-        self.assertIsNone(token.sub)
-        self.assertIsNone(token.aud)
-        self.assertIsNone(token.iss)
-        self.assertIsNone(token.jti)
+        assert token.active is None
+        assert token.scope is None
+        assert token.client_id is None
+        assert token.username is None
+        assert token.token_type is None
+        assert token.exp is None
+        assert token.iat is None
+        assert token.nbf is None
+        assert token.sub is None
+        assert token.aud is None
+        assert token.iss is None
+        assert token.jti is None
 
     def test_invalid_attr(self):
         token = IntrospectionToken()
-        self.assertRaises(AttributeError, lambda: token.invalid)
+        with pytest.raises(AttributeError):
+            token.invalid  # noqa:B018

--- a/tests/core/test_oidc/test_registration.py
+++ b/tests/core/test_oidc/test_registration.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import pytest
+
 from authlib.jose.errors import InvalidClaimError
 from authlib.oidc.registration import ClientMetadataClaims
 
@@ -12,7 +14,8 @@ class ClientMetadataClaimsTest(TestCase):
         claims.validate()
 
         claims = ClientMetadataClaims({"request_uris": ["invalid"]}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_initiate_login_uri(self):
         claims = ClientMetadataClaims(
@@ -21,7 +24,8 @@ class ClientMetadataClaimsTest(TestCase):
         claims.validate()
 
         claims = ClientMetadataClaims({"initiate_login_uri": "invalid"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_token_endpoint_auth_signing_alg(self):
         claims = ClientMetadataClaims({"token_endpoint_auth_signing_alg": "RSA256"}, {})
@@ -29,7 +33,8 @@ class ClientMetadataClaimsTest(TestCase):
 
         # The value none MUST NOT be used.
         claims = ClientMetadataClaims({"token_endpoint_auth_signing_alg": "none"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()
 
     def test_id_token_signed_response_alg(self):
         claims = ClientMetadataClaims({"id_token_signed_response_alg": "RSA256"}, {})
@@ -41,4 +46,5 @@ class ClientMetadataClaimsTest(TestCase):
 
         # The value none MUST NOT be used.
         claims = ClientMetadataClaims({"default_max_age": "invalid"}, {})
-        self.assertRaises(InvalidClaimError, claims.validate)
+        with pytest.raises(InvalidClaimError):
+            claims.validate()

--- a/tests/django/test_oauth1/test_resource_protector.py
+++ b/tests/django/test_oauth1/test_resource_protector.py
@@ -56,14 +56,14 @@ class ResourceTest(TestCase):
         request = self.factory.get(url)
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_consumer_key", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_consumer_key" in data["error_description"]
 
         # case 2
         request = self.factory.get(add_params_to_uri(url, {"oauth_consumer_key": "a"}))
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         # case 3
         request = self.factory.get(
@@ -71,8 +71,8 @@ class ResourceTest(TestCase):
         )
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_token", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_token" in data["error_description"]
 
         # case 4
         request = self.factory.get(
@@ -80,7 +80,7 @@ class ResourceTest(TestCase):
         )
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "invalid_token")
+        assert data["error"] == "invalid_token"
 
         # case 5
         request = self.factory.get(
@@ -90,8 +90,8 @@ class ResourceTest(TestCase):
         )
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_timestamp", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_timestamp" in data["error_description"]
 
     @override_settings(AUTHLIB_OAUTH1_PROVIDER={"signature_methods": ["PLAINTEXT"]})
     def test_plaintext_signature(self):
@@ -109,14 +109,14 @@ class ResourceTest(TestCase):
         request = self.factory.get(url, HTTP_AUTHORIZATION=auth_header)
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertIn("username", data)
+        assert "username" in data
 
         # case 2: invalid signature
         auth_header = auth_header.replace("valid-token-secret", "invalid")
         request = self.factory.get(url, HTTP_AUTHORIZATION=auth_header)
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"
 
     def test_hmac_sha1_signature(self):
         self.prepare_data()
@@ -142,13 +142,13 @@ class ResourceTest(TestCase):
         request = self.factory.get(url, HTTP_AUTHORIZATION=auth_header)
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertIn("username", data)
+        assert "username" in data
 
         # case 2: exists nonce
         request = self.factory.get(url, HTTP_AUTHORIZATION=auth_header)
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "invalid_nonce")
+        assert data["error"] == "invalid_nonce"
 
     @override_settings(AUTHLIB_OAUTH1_PROVIDER={"signature_methods": ["RSA-SHA1"]})
     def test_rsa_sha1_signature(self):
@@ -177,7 +177,7 @@ class ResourceTest(TestCase):
         request = self.factory.get(url, HTTP_AUTHORIZATION=auth_header)
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertIn("username", data)
+        assert "username" in data
 
         # case: invalid signature
         auth_param = auth_param.replace("rsa-sha1-nonce", "alt-sha1-nonce")
@@ -185,4 +185,4 @@ class ResourceTest(TestCase):
         request = self.factory.get(url, HTTP_AUTHORIZATION=auth_header)
         resp = handle(request)
         data = json.loads(to_unicode(resp.content))
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"

--- a/tests/django/test_oauth1/test_token_credentials.py
+++ b/tests/django/test_oauth1/test_token_credentials.py
@@ -45,21 +45,21 @@ class AuthorizationTest(TestCase):
         request = self.factory.post(url)
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_consumer_key", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_consumer_key" in data["error_description"]
 
         # case 2
         request = self.factory.post(url, data={"oauth_consumer_key": "a"})
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         # case 3
         request = self.factory.post(url, data={"oauth_consumer_key": "client"})
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_token", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_token" in data["error_description"]
 
         # case 4
         request = self.factory.post(
@@ -67,7 +67,7 @@ class AuthorizationTest(TestCase):
         )
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "invalid_token")
+        assert data["error"] == "invalid_token"
 
     def test_duplicated_oauth_parameters(self):
         self.prepare_data()
@@ -83,7 +83,7 @@ class AuthorizationTest(TestCase):
         )
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "duplicated_oauth_protocol_parameter")
+        assert data["error"] == "duplicated_oauth_protocol_parameter"
 
     @override_settings(AUTHLIB_OAUTH1_PROVIDER={"signature_methods": ["PLAINTEXT"]})
     def test_plaintext_signature(self):
@@ -103,7 +103,7 @@ class AuthorizationTest(TestCase):
         request = self.factory.post(url, HTTP_AUTHORIZATION=auth_header)
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case 2: invalid signature
         self.prepare_temporary_credential(server)
@@ -119,7 +119,7 @@ class AuthorizationTest(TestCase):
         )
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"
 
     def test_hmac_sha1_signature(self):
         self.prepare_data()
@@ -147,14 +147,14 @@ class AuthorizationTest(TestCase):
         request = self.factory.post(url, HTTP_AUTHORIZATION=auth_header)
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case 2: exists nonce
         self.prepare_temporary_credential(server)
         request = self.factory.post(url, HTTP_AUTHORIZATION=auth_header)
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "invalid_nonce")
+        assert data["error"] == "invalid_nonce"
 
     @override_settings(AUTHLIB_OAUTH1_PROVIDER={"signature_methods": ["RSA-SHA1"]})
     def test_rsa_sha1_signature(self):
@@ -184,7 +184,7 @@ class AuthorizationTest(TestCase):
         request = self.factory.post(url, HTTP_AUTHORIZATION=auth_header)
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case: invalid signature
         self.prepare_temporary_credential(server)
@@ -193,4 +193,4 @@ class AuthorizationTest(TestCase):
         request = self.factory.post(url, HTTP_AUTHORIZATION=auth_header)
         resp = server.create_token_response(request)
         data = decode_response(resp.content)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"

--- a/tests/django/test_oauth2/test_client_credentials_grant.py
+++ b/tests/django/test_oauth2/test_client_credentials_grant.py
@@ -35,9 +35,9 @@ class PasswordTest(TestCase):
             data={"grant_type": "client_credentials"},
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         request = self.factory.post(
             "/oauth/token",
@@ -45,9 +45,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("invalid", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
     def test_invalid_scope(self):
         server = self.create_server()
@@ -59,9 +59,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_scope")
+        assert data["error"] == "invalid_scope"
 
     def test_invalid_request(self):
         server = self.create_server()
@@ -72,9 +72,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "unsupported_grant_type")
+        assert data["error"] == "unsupported_grant_type"
 
     def test_unauthorized_client(self):
         server = self.create_server()
@@ -85,9 +85,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "unauthorized_client")
+        assert data["error"] == "unauthorized_client"
 
     def test_authorize_token(self):
         server = self.create_server()
@@ -98,6 +98,6 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertIn("access_token", data)
+        assert "access_token" in data

--- a/tests/django/test_oauth2/test_implicit_grant.py
+++ b/tests/django/test_oauth2/test_implicit_grant.py
@@ -1,3 +1,5 @@
+import pytest
+
 from authlib.common.urls import url_decode
 from authlib.common.urls import urlparse
 from authlib.oauth2.rfc6749 import errors
@@ -31,16 +33,17 @@ class ImplicitTest(TestCase):
         server = self.create_server()
         url = "/authorize?response_type=token"
         request = self.factory.get(url)
-        self.assertRaises(errors.InvalidClientError, server.get_consent_grant, request)
+        with pytest.raises(errors.InvalidClientError):
+            server.get_consent_grant(request)
 
         url = "/authorize?response_type=token&client_id=client"
         request = self.factory.get(url)
-        self.assertRaises(errors.InvalidClientError, server.get_consent_grant, request)
+        with pytest.raises(errors.InvalidClientError):
+            server.get_consent_grant(request)
 
         self.prepare_data(response_type="")
-        self.assertRaises(
-            errors.UnauthorizedClientError, server.get_consent_grant, request
-        )
+        with pytest.raises(errors.UnauthorizedClientError):
+            server.get_consent_grant(request)
 
     def test_get_consent_grant_scope(self):
         server = self.create_server()
@@ -50,7 +53,8 @@ class ImplicitTest(TestCase):
         base_url = "/authorize?response_type=token&client_id=client"
         url = base_url + "&scope=invalid"
         request = self.factory.get(url)
-        self.assertRaises(errors.InvalidScopeError, server.get_consent_grant, request)
+        with pytest.raises(errors.InvalidScopeError):
+            server.get_consent_grant(request)
 
     def test_create_authorization_response(self):
         server = self.create_server()
@@ -60,12 +64,12 @@ class ImplicitTest(TestCase):
         server.get_consent_grant(request)
 
         resp = server.create_authorization_response(request)
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
         params = dict(url_decode(urlparse.urlparse(resp["Location"]).fragment))
-        self.assertEqual(params["error"], "access_denied")
+        assert params["error"] == "access_denied"
 
         grant_user = User.objects.get(username="foo")
         resp = server.create_authorization_response(request, grant_user=grant_user)
-        self.assertEqual(resp.status_code, 302)
+        assert resp.status_code == 302
         params = dict(url_decode(urlparse.urlparse(resp["Location"]).fragment))
-        self.assertIn("access_token", params)
+        assert "access_token" in params

--- a/tests/django/test_oauth2/test_password_grant.py
+++ b/tests/django/test_oauth2/test_password_grant.py
@@ -48,9 +48,9 @@ class PasswordTest(TestCase):
             data={"grant_type": "password", "username": "foo", "password": "ok"},
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         request = self.factory.post(
             "/oauth/token",
@@ -58,9 +58,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("invalid", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
     def test_invalid_scope(self):
         server = self.create_server()
@@ -77,9 +77,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_scope")
+        assert data["error"] == "invalid_scope"
 
     def test_invalid_request(self):
         server = self.create_server()
@@ -92,9 +92,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "unsupported_grant_type")
+        assert data["error"] == "unsupported_grant_type"
 
         # case 2
         request = self.factory.post(
@@ -103,9 +103,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_request")
+        assert data["error"] == "invalid_request"
 
         # case 3
         request = self.factory.post(
@@ -114,9 +114,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_request")
+        assert data["error"] == "invalid_request"
 
         # case 4
         request = self.factory.post(
@@ -129,9 +129,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_request")
+        assert data["error"] == "invalid_request"
 
     def test_unauthorized_client(self):
         server = self.create_server()
@@ -146,9 +146,9 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "unauthorized_client")
+        assert data["error"] == "unauthorized_client"
 
     def test_authorize_token(self):
         server = self.create_server()
@@ -163,6 +163,6 @@ class PasswordTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertIn("access_token", data)
+        assert "access_token" in data

--- a/tests/django/test_oauth2/test_refresh_token.py
+++ b/tests/django/test_oauth2/test_refresh_token.py
@@ -69,9 +69,9 @@ class RefreshTokenTest(TestCase):
             data={"grant_type": "refresh_token", "refresh_token": "foo"},
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         request = self.factory.post(
             "/oauth/token",
@@ -79,9 +79,9 @@ class RefreshTokenTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("invalid", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
     def test_invalid_refresh_token(self):
         self.prepare_client()
@@ -93,10 +93,10 @@ class RefreshTokenTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_request")
-        self.assertIn("Missing", data["error_description"])
+        assert data["error"] == "invalid_request"
+        assert "Missing" in data["error_description"]
 
         request = self.factory.post(
             "/oauth/token",
@@ -104,9 +104,9 @@ class RefreshTokenTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_grant")
+        assert data["error"] == "invalid_grant"
 
     def test_invalid_scope(self):
         server = self.create_server()
@@ -123,9 +123,9 @@ class RefreshTokenTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_scope")
+        assert data["error"] == "invalid_scope"
 
     def test_authorize_tno_scope(self):
         server = self.create_server()
@@ -141,9 +141,9 @@ class RefreshTokenTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertIn("access_token", data)
+        assert "access_token" in data
 
     def test_authorize_token_scope(self):
         server = self.create_server()
@@ -160,9 +160,9 @@ class RefreshTokenTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertIn("access_token", data)
+        assert "access_token" in data
 
     def test_revoke_old_token(self):
         server = self.create_server()
@@ -179,9 +179,9 @@ class RefreshTokenTest(TestCase):
             HTTP_AUTHORIZATION=self.create_basic_auth("client", "secret"),
         )
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertIn("access_token", data)
+        assert "access_token" in data
 
         resp = server.create_token_response(request)
-        self.assertEqual(resp.status_code, 400)
+        assert resp.status_code == 400

--- a/tests/django/test_oauth2/test_resource_protector.py
+++ b/tests/django/test_oauth2/test_resource_protector.py
@@ -46,21 +46,21 @@ class ResourceProtectorTest(TestCase):
 
         request = self.factory.get("/user")
         resp = get_user_profile(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "missing_authorization")
+        assert data["error"] == "missing_authorization"
 
         request = self.factory.get("/user", HTTP_AUTHORIZATION="invalid token")
         resp = get_user_profile(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "unsupported_token_type")
+        assert data["error"] == "unsupported_token_type"
 
         request = self.factory.get("/user", HTTP_AUTHORIZATION="bearer token")
         resp = get_user_profile(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_token")
+        assert data["error"] == "invalid_token"
 
     def test_expired_token(self):
         self.prepare_data(-10)
@@ -72,9 +72,9 @@ class ResourceProtectorTest(TestCase):
 
         request = self.factory.get("/user", HTTP_AUTHORIZATION="bearer a1")
         resp = get_user_profile(request)
-        self.assertEqual(resp.status_code, 401)
+        assert resp.status_code == 401
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_token")
+        assert data["error"] == "invalid_token"
 
     def test_insufficient_token(self):
         self.prepare_data()
@@ -86,9 +86,9 @@ class ResourceProtectorTest(TestCase):
 
         request = self.factory.get("/user/email", HTTP_AUTHORIZATION="bearer a1")
         resp = get_user_email(request)
-        self.assertEqual(resp.status_code, 403)
+        assert resp.status_code == 403
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "insufficient_scope")
+        assert data["error"] == "insufficient_scope"
 
     def test_access_resource(self):
         self.prepare_data()
@@ -102,15 +102,15 @@ class ResourceProtectorTest(TestCase):
 
         request = self.factory.get("/user")
         resp = get_user_profile(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertEqual(data["username"], "anonymous")
+        assert data["username"] == "anonymous"
 
         request = self.factory.get("/user", HTTP_AUTHORIZATION="bearer a1")
         resp = get_user_profile(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertEqual(data["username"], "foo")
+        assert data["username"] == "foo"
 
     def test_scope_operator(self):
         self.prepare_data()
@@ -127,11 +127,11 @@ class ResourceProtectorTest(TestCase):
 
         request = self.factory.get("/user", HTTP_AUTHORIZATION="bearer a1")
         resp = operator_and(request)
-        self.assertEqual(resp.status_code, 403)
+        assert resp.status_code == 403
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "insufficient_scope")
+        assert data["error"] == "insufficient_scope"
 
         resp = operator_or(request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
         data = json.loads(resp.content)
-        self.assertEqual(data["username"], "foo")
+        assert data["username"] == "foo"

--- a/tests/django/test_oauth2/test_revocation_endpoint.py
+++ b/tests/django/test_oauth2/test_revocation_endpoint.py
@@ -45,12 +45,12 @@ class RevocationEndpointTest(TestCase):
         request = self.factory.post("/oauth/revoke")
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         request = self.factory.post("/oauth/revoke", HTTP_AUTHORIZATION="invalid token")
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         request = self.factory.post(
             "/oauth/revoke",
@@ -58,7 +58,7 @@ class RevocationEndpointTest(TestCase):
         )
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         request = self.factory.post(
             "/oauth/revoke",
@@ -66,7 +66,7 @@ class RevocationEndpointTest(TestCase):
         )
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
     def test_invalid_token(self):
         server = self.create_server()
@@ -77,7 +77,7 @@ class RevocationEndpointTest(TestCase):
         request = self.factory.post("/oauth/revoke", HTTP_AUTHORIZATION=auth_header)
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "invalid_request")
+        assert data["error"] == "invalid_request"
 
         # case 1
         request = self.factory.post(
@@ -86,7 +86,7 @@ class RevocationEndpointTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
 
         # case 2
         request = self.factory.post(
@@ -99,7 +99,7 @@ class RevocationEndpointTest(TestCase):
         )
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
         data = json.loads(resp.content)
-        self.assertEqual(data["error"], "unsupported_token_type")
+        assert data["error"] == "unsupported_token_type"
 
         # case 3
         request = self.factory.post(
@@ -111,7 +111,7 @@ class RevocationEndpointTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200
 
     def test_revoke_token_with_hint(self):
         self.prepare_client()
@@ -135,4 +135,4 @@ class RevocationEndpointTest(TestCase):
             HTTP_AUTHORIZATION=auth_header,
         )
         resp = server.create_endpoint_response(ENDPOINT_NAME, request)
-        self.assertEqual(resp.status_code, 200)
+        assert resp.status_code == 200

--- a/tests/flask/test_oauth1/test_authorize.py
+++ b/tests/flask/test_oauth1/test_authorize.py
@@ -31,13 +31,13 @@ class AuthorizationWithCacheTest(TestCase):
         # case 1
         rv = self.client.post(url, data={"user_id": "1"})
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_token", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_token" in data["error_description"]
 
         # case 2
         rv = self.client.post(url, data={"user_id": "1", "oauth_token": "a"})
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_token")
+        assert data["error"] == "invalid_token"
 
     def test_authorize_denied(self):
         self.prepare_data()
@@ -54,12 +54,12 @@ class AuthorizationWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         rv = self.client.post(authorize_url, data={"oauth_token": data["oauth_token"]})
-        self.assertEqual(rv.status_code, 302)
-        self.assertIn("access_denied", rv.headers["Location"])
-        self.assertIn("https://a.b", rv.headers["Location"])
+        assert rv.status_code == 302
+        assert "access_denied" in rv.headers["Location"]
+        assert "https://a.b" in rv.headers["Location"]
 
         rv = self.client.post(
             initiate_url,
@@ -71,12 +71,12 @@ class AuthorizationWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         rv = self.client.post(authorize_url, data={"oauth_token": data["oauth_token"]})
-        self.assertEqual(rv.status_code, 302)
-        self.assertIn("access_denied", rv.headers["Location"])
-        self.assertIn("https://i.test", rv.headers["Location"])
+        assert rv.status_code == 302
+        assert "access_denied" in rv.headers["Location"]
+        assert "https://i.test" in rv.headers["Location"]
 
     def test_authorize_granted(self):
         self.prepare_data()
@@ -93,14 +93,14 @@ class AuthorizationWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         rv = self.client.post(
             authorize_url, data={"user_id": "1", "oauth_token": data["oauth_token"]}
         )
-        self.assertEqual(rv.status_code, 302)
-        self.assertIn("oauth_verifier", rv.headers["Location"])
-        self.assertIn("https://a.b", rv.headers["Location"])
+        assert rv.status_code == 302
+        assert "oauth_verifier" in rv.headers["Location"]
+        assert "https://a.b" in rv.headers["Location"]
 
         rv = self.client.post(
             initiate_url,
@@ -112,14 +112,14 @@ class AuthorizationWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         rv = self.client.post(
             authorize_url, data={"user_id": "1", "oauth_token": data["oauth_token"]}
         )
-        self.assertEqual(rv.status_code, 302)
-        self.assertIn("oauth_verifier", rv.headers["Location"])
-        self.assertIn("https://i.test", rv.headers["Location"])
+        assert rv.status_code == 302
+        assert "oauth_verifier" in rv.headers["Location"]
+        assert "https://i.test" in rv.headers["Location"]
 
 
 class AuthorizationNoCacheTest(AuthorizationWithCacheTest):

--- a/tests/flask/test_oauth1/test_resource_protector.py
+++ b/tests/flask/test_oauth1/test_resource_protector.py
@@ -48,26 +48,26 @@ class ResourceCacheTest(TestCase):
         # case 1
         rv = self.client.get(url)
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_consumer_key", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_consumer_key" in data["error_description"]
 
         # case 2
         rv = self.client.get(add_params_to_uri(url, {"oauth_consumer_key": "a"}))
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         # case 3
         rv = self.client.get(add_params_to_uri(url, {"oauth_consumer_key": "client"}))
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_token", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_token" in data["error_description"]
 
         # case 4
         rv = self.client.get(
             add_params_to_uri(url, {"oauth_consumer_key": "client", "oauth_token": "a"})
         )
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "invalid_token")
+        assert data["error"] == "invalid_token"
 
         # case 5
         rv = self.client.get(
@@ -76,8 +76,8 @@ class ResourceCacheTest(TestCase):
             )
         )
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_timestamp", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_timestamp" in data["error_description"]
 
     def test_plaintext_signature(self):
         self.prepare_data()
@@ -93,14 +93,14 @@ class ResourceCacheTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.get(url, headers=headers)
         data = json.loads(rv.data)
-        self.assertIn("username", data)
+        assert "username" in data
 
         # case 2: invalid signature
         auth_header = auth_header.replace("valid-token-secret", "invalid")
         headers = {"Authorization": auth_header}
         rv = self.client.get(url, headers=headers)
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"
 
     def test_hmac_sha1_signature(self):
         self.prepare_data()
@@ -125,12 +125,12 @@ class ResourceCacheTest(TestCase):
         # case 1: success
         rv = self.client.get(url, headers=headers)
         data = json.loads(rv.data)
-        self.assertIn("username", data)
+        assert "username" in data
 
         # case 2: exists nonce
         rv = self.client.get(url, headers=headers)
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "invalid_nonce")
+        assert data["error"] == "invalid_nonce"
 
     def test_rsa_sha1_signature(self):
         self.prepare_data()
@@ -155,7 +155,7 @@ class ResourceCacheTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.get(url, headers=headers)
         data = json.loads(rv.data)
-        self.assertIn("username", data)
+        assert "username" in data
 
         # case: invalid signature
         auth_param = auth_param.replace("rsa-sha1-nonce", "alt-sha1-nonce")
@@ -163,7 +163,7 @@ class ResourceCacheTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.get(url, headers=headers)
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"
 
 
 class ResourceDBTest(ResourceCacheTest):

--- a/tests/flask/test_oauth1/test_temporary_credentials.py
+++ b/tests/flask/test_oauth1/test_temporary_credentials.py
@@ -34,34 +34,34 @@ class TemporaryCredentialsWithCacheTest(TestCase):
 
         rv = self.client.get(url)
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "method_not_allowed")
+        assert data["error"] == "method_not_allowed"
 
         # case 1
         rv = self.client.post(url)
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_consumer_key", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_consumer_key" in data["error_description"]
 
         # case 2
         rv = self.client.post(url, data={"oauth_consumer_key": "client"})
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_callback", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_callback" in data["error_description"]
 
         # case 3
         rv = self.client.post(
             url, data={"oauth_consumer_key": "client", "oauth_callback": "invalid_url"}
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_request")
-        self.assertIn("oauth_callback", data["error_description"])
+        assert data["error"] == "invalid_request"
+        assert "oauth_callback" in data["error_description"]
 
         # case 4
         rv = self.client.post(
             url, data={"oauth_consumer_key": "invalid-client", "oauth_callback": "oob"}
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
     def test_validate_timestamp_and_nonce(self):
         self.prepare_data()
@@ -72,8 +72,8 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             url, data={"oauth_consumer_key": "client", "oauth_callback": "oob"}
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_timestamp", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_timestamp" in data["error_description"]
 
         # case 6
         rv = self.client.post(
@@ -85,8 +85,8 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_nonce", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_nonce" in data["error_description"]
 
         # case 7
         rv = self.client.post(
@@ -98,8 +98,8 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_request")
-        self.assertIn("oauth_timestamp", data["error_description"])
+        assert data["error"] == "invalid_request"
+        assert "oauth_timestamp" in data["error_description"]
 
         # case 8
         rv = self.client.post(
@@ -111,8 +111,8 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_request")
-        self.assertIn("oauth_timestamp", data["error_description"])
+        assert data["error"] == "invalid_request"
+        assert "oauth_timestamp" in data["error_description"]
 
         # case 9
         rv = self.client.post(
@@ -124,8 +124,8 @@ class TemporaryCredentialsWithCacheTest(TestCase):
                 "oauth_signature_method": "PLAINTEXT",
             },
         )
-        self.assertEqual(data["error"], "invalid_request")
-        self.assertIn("oauth_timestamp", data["error_description"])
+        assert data["error"] == "invalid_request"
+        assert "oauth_timestamp" in data["error_description"]
 
     def test_temporary_credential_signatures_errors(self):
         self.prepare_data()
@@ -140,8 +140,8 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_signature", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_signature" in data["error_description"]
 
         rv = self.client.post(
             url,
@@ -153,8 +153,8 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_signature_method", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_signature_method" in data["error_description"]
 
         rv = self.client.post(
             url,
@@ -168,7 +168,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "unsupported_signature_method")
+        assert data["error"] == "unsupported_signature_method"
 
     def test_plaintext_signature(self):
         self.prepare_data()
@@ -185,7 +185,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case 2: use header
         auth_header = (
@@ -197,7 +197,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case 3: invalid signature
         rv = self.client.post(
@@ -210,7 +210,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"
 
     def test_hmac_sha1_signature(self):
         self.prepare_data()
@@ -235,12 +235,12 @@ class TemporaryCredentialsWithCacheTest(TestCase):
         # case 1: success
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case 2: exists nonce
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_nonce")
+        assert data["error"] == "invalid_nonce"
 
     def test_rsa_sha1_signature(self):
         self.prepare_data()
@@ -265,7 +265,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case: invalid signature
         auth_param = auth_param.replace("rsa-sha1-nonce", "alt-sha1-nonce")
@@ -273,7 +273,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"
 
     def test_invalid_signature(self):
         self.app.config.update({"OAUTH1_SUPPORTED_SIGNATURE_METHODS": ["INVALID"]})
@@ -289,7 +289,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "unsupported_signature_method")
+        assert data["error"] == "unsupported_signature_method"
 
         rv = self.client.post(
             url,
@@ -303,7 +303,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "unsupported_signature_method")
+        assert data["error"] == "unsupported_signature_method"
 
     def test_register_signature_method(self):
         self.prepare_data()
@@ -312,7 +312,7 @@ class TemporaryCredentialsWithCacheTest(TestCase):
             pass
 
         self.server.register_signature_method("foo", foo)
-        self.assertEqual(self.server.SIGNATURE_METHODS["foo"], foo)
+        assert self.server.SIGNATURE_METHODS["foo"] == foo
 
 
 class TemporaryCredentialsNoCacheTest(TemporaryCredentialsWithCacheTest):

--- a/tests/flask/test_oauth1/test_token_credentials.py
+++ b/tests/flask/test_oauth1/test_token_credentials.py
@@ -45,26 +45,26 @@ class TokenCredentialsTest(TestCase):
         # case 1
         rv = self.client.post(url)
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_consumer_key", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_consumer_key" in data["error_description"]
 
         # case 2
         rv = self.client.post(url, data={"oauth_consumer_key": "a"})
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_client")
+        assert data["error"] == "invalid_client"
 
         # case 3
         rv = self.client.post(url, data={"oauth_consumer_key": "client"})
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_token", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_token" in data["error_description"]
 
         # case 4
         rv = self.client.post(
             url, data={"oauth_consumer_key": "client", "oauth_token": "a"}
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_token")
+        assert data["error"] == "invalid_token"
 
     def test_invalid_token_and_verifiers(self):
         self.prepare_data()
@@ -79,8 +79,8 @@ class TokenCredentialsTest(TestCase):
             url, data={"oauth_consumer_key": "client", "oauth_token": "abc"}
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "missing_required_parameter")
-        self.assertIn("oauth_verifier", data["error_description"])
+        assert data["error"] == "missing_required_parameter"
+        assert "oauth_verifier" in data["error_description"]
 
         # case 6
         hook(
@@ -95,8 +95,8 @@ class TokenCredentialsTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_request")
-        self.assertIn("oauth_verifier", data["error_description"])
+        assert data["error"] == "invalid_request"
+        assert "oauth_verifier" in data["error_description"]
 
     def test_duplicated_oauth_parameters(self):
         self.prepare_data()
@@ -110,7 +110,7 @@ class TokenCredentialsTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "duplicated_oauth_protocol_parameter")
+        assert data["error"] == "duplicated_oauth_protocol_parameter"
 
     def test_plaintext_signature(self):
         self.prepare_data()
@@ -128,7 +128,7 @@ class TokenCredentialsTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case 2: invalid signature
         self.prepare_temporary_credential()
@@ -143,7 +143,7 @@ class TokenCredentialsTest(TestCase):
             },
         )
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"
 
     def test_hmac_sha1_signature(self):
         self.prepare_data()
@@ -170,13 +170,13 @@ class TokenCredentialsTest(TestCase):
         self.prepare_temporary_credential()
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case 2: exists nonce
         self.prepare_temporary_credential()
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_nonce")
+        assert data["error"] == "invalid_nonce"
 
     def test_rsa_sha1_signature(self):
         self.prepare_data()
@@ -203,7 +203,7 @@ class TokenCredentialsTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertIn("oauth_token", data)
+        assert "oauth_token" in data
 
         # case: invalid signature
         self.prepare_temporary_credential()
@@ -212,4 +212,4 @@ class TokenCredentialsTest(TestCase):
         headers = {"Authorization": auth_header}
         rv = self.client.post(url, headers=headers)
         data = decode_response(rv.data)
-        self.assertEqual(data["error"], "invalid_signature")
+        assert data["error"] == "invalid_signature"

--- a/tests/flask/test_oauth2/test_authorization_code_iss_parameter.py
+++ b/tests/flask/test_oauth2/test_authorization_code_iss_parameter.py
@@ -73,7 +73,7 @@ class RFC9207AuthorizationCodeTest(TestCase):
         self.prepare_data(rfc9207=True)
         url = self.authorize_url + "&state=bar"
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("iss=https%3A%2F%2Fauth.test", rv.location)
+        assert "iss=https%3A%2F%2Fauth.test" in rv.location
 
     def test_rfc9207_disabled_success_no_iss(self):
         """Check that when RFC9207 is not implemented,
@@ -82,7 +82,7 @@ class RFC9207AuthorizationCodeTest(TestCase):
         self.prepare_data(rfc9207=False)
         url = self.authorize_url + "&state=bar"
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertNotIn("iss=", rv.location)
+        assert "iss=" not in rv.location
 
     def test_rfc9207_enabled_error(self):
         """Check that when RFC9207 is implemented,
@@ -91,8 +91,8 @@ class RFC9207AuthorizationCodeTest(TestCase):
 
         self.prepare_data(rfc9207=True)
         rv = self.client.post(self.authorize_url)
-        self.assertIn("error=access_denied", rv.location)
-        self.assertIn("iss=https%3A%2F%2Fauth.test", rv.location)
+        assert "error=access_denied" in rv.location
+        assert "iss=https%3A%2F%2Fauth.test" in rv.location
 
     def test_rfc9207_disbled_error_no_iss(self):
         """Check that when RFC9207 is not implemented,
@@ -101,5 +101,5 @@ class RFC9207AuthorizationCodeTest(TestCase):
 
         self.prepare_data(rfc9207=False)
         rv = self.client.post(self.authorize_url)
-        self.assertIn("error=access_denied", rv.location)
-        self.assertNotIn("iss=", rv.location)
+        assert "error=access_denied" in rv.location
+        assert "iss=" not in rv.location

--- a/tests/flask/test_oauth2/test_client_configuration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_configuration_endpoint.py
@@ -105,31 +105,31 @@ class ClientConfigurationTestMixin(TestCase):
 class ClientConfigurationReadTest(ClientConfigurationTestMixin):
     def test_read_client(self):
         user, client, token = self.prepare_data()
-        self.assertEqual(client.client_name, "Authlib")
+        assert client.client_name == "Authlib"
         headers = {"Authorization": f"bearer {token.access_token}"}
         rv = self.client.get("/configure_client/client_id", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 200)
-        self.assertEqual(resp["client_id"], client.client_id)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(
-            resp["registration_client_uri"],
-            "http://localhost/configure_client/client_id",
+        assert rv.status_code == 200
+        assert resp["client_id"] == client.client_id
+        assert resp["client_name"] == "Authlib"
+        assert (
+            resp["registration_client_uri"]
+            == "http://localhost/configure_client/client_id"
         )
-        self.assertEqual(resp["registration_access_token"], token.access_token)
+        assert resp["registration_access_token"] == token.access_token
 
     def test_access_denied(self):
         user, client, token = self.prepare_data()
         rv = self.client.get("/configure_client/client_id")
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
         headers = {"Authorization": "bearer invalid_token"}
         rv = self.client.get("/configure_client/client_id", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
         headers = {"Authorization": "bearer unauthorized_token"}
         rv = self.client.get(
@@ -138,8 +138,8 @@ class ClientConfigurationReadTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
     def test_invalid_client(self):
         # If the client does not exist on this server, the server MUST respond
@@ -150,8 +150,8 @@ class ClientConfigurationReadTest(ClientConfigurationTestMixin):
         headers = {"Authorization": f"bearer {token.access_token}"}
         rv = self.client.get("/configure_client/invalid_client_id", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 401)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert rv.status_code == 401
+        assert resp["error"] == "invalid_client"
 
     def test_unauthorized_client(self):
         # If the client does not have permission to read its record, the server
@@ -170,8 +170,8 @@ class ClientConfigurationReadTest(ClientConfigurationTestMixin):
             "/configure_client/unauthorized_client_id", headers=headers
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 403)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert rv.status_code == 403
+        assert resp["error"] == "unauthorized_client"
 
 
 class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
@@ -184,7 +184,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         # value in the request just as any other value.
 
         user, client, token = self.prepare_data()
-        self.assertEqual(client.client_name, "Authlib")
+        assert client.client_name == "Authlib"
         headers = {"Authorization": f"bearer {token.access_token}"}
         body = {
             "client_id": client.client_id,
@@ -192,24 +192,24 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 200)
-        self.assertEqual(resp["client_id"], client.client_id)
-        self.assertEqual(resp["client_name"], "NewAuthlib")
-        self.assertEqual(client.client_name, "NewAuthlib")
-        self.assertEqual(client.scope, "")
+        assert rv.status_code == 200
+        assert resp["client_id"] == client.client_id
+        assert resp["client_name"] == "NewAuthlib"
+        assert client.client_name == "NewAuthlib"
+        assert client.scope == ""
 
     def test_access_denied(self):
         user, client, token = self.prepare_data()
         rv = self.client.put("/configure_client/client_id", json={})
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
         headers = {"Authorization": "bearer invalid_token"}
         rv = self.client.put("/configure_client/client_id", json={}, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
         headers = {"Authorization": "bearer unauthorized_token"}
         rv = self.client.put(
@@ -218,8 +218,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
     def test_invalid_request(self):
         user, client, token = self.prepare_data()
@@ -228,8 +228,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         # The client MUST include its 'client_id' field in the request...
         rv = self.client.put("/configure_client/client_id", json={}, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
 
         # ... and it MUST be the same as its currently issued client identifier.
         rv = self.client.put(
@@ -238,8 +238,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
 
         # The updated client metadata fields request MUST NOT include the
         # 'registration_access_token', 'registration_client_uri',
@@ -253,8 +253,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
 
         # If the client includes the 'client_secret' field in the request,
         # the value of this field MUST match the currently issued client
@@ -265,8 +265,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_request"
 
     def test_invalid_client(self):
         # If the client does not exist on this server, the server MUST respond
@@ -281,8 +281,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 401)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert rv.status_code == 401
+        assert resp["error"] == "invalid_client"
 
     def test_unauthorized_client(self):
         # If the client does not have permission to read its record, the server
@@ -306,8 +306,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 403)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert rv.status_code == 403
+        assert resp["error"] == "unauthorized_client"
 
     def test_invalid_metadata(self):
         metadata = {"token_endpoint_auth_methods_supported": ["client_secret_basic"]}
@@ -328,8 +328,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "invalid_client_metadata")
+        assert rv.status_code == 400
+        assert resp["error"] == "invalid_client_metadata"
 
     def test_scopes_supported(self):
         metadata = {"scopes_supported": ["profile", "email"]}
@@ -343,9 +343,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["client_id"], "client_id")
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["scope"], "profile email")
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["scope"] == "profile email"
 
         headers = {"Authorization": f"bearer {token.access_token}"}
         body = {
@@ -355,8 +355,8 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["client_id"], "client_id")
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
 
         body = {
             "client_id": "client_id",
@@ -365,7 +365,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_response_types_supported(self):
         metadata = {"response_types_supported": ["code"]}
@@ -379,9 +379,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["client_id"], "client_id")
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["response_types"], ["code"])
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["response_types"] == ["code"]
 
         # https://datatracker.ietf.org/doc/html/rfc7592#section-2.2
         # If omitted, the default is that the client will use only the "code"
@@ -389,9 +389,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         body = {"client_id": "client_id", "client_name": "Authlib"}
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertNotIn("response_types", resp)
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert "response_types" not in resp
 
         body = {
             "client_id": "client_id",
@@ -400,7 +400,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_grant_types_supported(self):
         metadata = {"grant_types_supported": ["authorization_code", "password"]}
@@ -414,9 +414,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["client_id"], "client_id")
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["grant_types"], ["password"])
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["grant_types"] == ["password"]
 
         # https://datatracker.ietf.org/doc/html/rfc7592#section-2.2
         # If omitted, the default behavior is that the client will use only
@@ -424,9 +424,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         body = {"client_id": "client_id", "client_name": "Authlib"}
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertNotIn("grant_types", resp)
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert "grant_types" not in resp
 
         body = {
             "client_id": "client_id",
@@ -435,7 +435,7 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_token_endpoint_auth_methods_supported(self):
         metadata = {"token_endpoint_auth_methods_supported": ["client_secret_basic"]}
@@ -449,9 +449,9 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["client_id"], "client_id")
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["token_endpoint_auth_method"], "client_secret_basic")
+        assert resp["client_id"] == "client_id"
+        assert resp["client_name"] == "Authlib"
+        assert resp["token_endpoint_auth_method"] == "client_secret_basic"
 
         body = {
             "client_id": "client_id",
@@ -460,30 +460,30 @@ class ClientConfigurationUpdateTest(ClientConfigurationTestMixin):
         }
         rv = self.client.put("/configure_client/client_id", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
 
 class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
     def test_delete_client(self):
         user, client, token = self.prepare_data()
-        self.assertEqual(client.client_name, "Authlib")
+        assert client.client_name == "Authlib"
         headers = {"Authorization": f"bearer {token.access_token}"}
         rv = self.client.delete("/configure_client/client_id", headers=headers)
-        self.assertEqual(rv.status_code, 204)
-        self.assertFalse(rv.data)
+        assert rv.status_code == 204
+        assert not rv.data
 
     def test_access_denied(self):
         user, client, token = self.prepare_data()
         rv = self.client.delete("/configure_client/client_id")
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
         headers = {"Authorization": "bearer invalid_token"}
         rv = self.client.delete("/configure_client/client_id", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
         headers = {"Authorization": "bearer unauthorized_token"}
         rv = self.client.delete(
@@ -492,8 +492,8 @@ class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 400)
-        self.assertEqual(resp["error"], "access_denied")
+        assert rv.status_code == 400
+        assert resp["error"] == "access_denied"
 
     def test_invalid_client(self):
         # If the client does not exist on this server, the server MUST respond
@@ -504,8 +504,8 @@ class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
         headers = {"Authorization": f"bearer {token.access_token}"}
         rv = self.client.delete("/configure_client/invalid_client_id", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 401)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert rv.status_code == 401
+        assert resp["error"] == "invalid_client"
 
     def test_unauthorized_client(self):
         # If the client does not have permission to read its record, the server
@@ -524,5 +524,5 @@ class ClientConfigurationDeleteTest(ClientConfigurationTestMixin):
             "/configure_client/unauthorized_client_id", headers=headers
         )
         resp = json.loads(rv.data)
-        self.assertEqual(rv.status_code, 403)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert rv.status_code == 403
+        assert resp["error"] == "unauthorized_client"

--- a/tests/flask/test_oauth2/test_client_credentials_grant.py
+++ b/tests/flask/test_oauth2/test_client_credentials_grant.py
@@ -42,7 +42,7 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("credential-client", "invalid-secret")
         rv = self.client.post(
@@ -53,7 +53,7 @@ class ClientCredentialsTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_invalid_grant_type(self):
         self.prepare_data(grant_type="invalid")
@@ -66,7 +66,7 @@ class ClientCredentialsTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert resp["error"] == "unauthorized_client"
 
     def test_invalid_scope(self):
         self.prepare_data()
@@ -81,7 +81,7 @@ class ClientCredentialsTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_scope")
+        assert resp["error"] == "invalid_scope"
 
     def test_authorize_token(self):
         self.prepare_data()
@@ -94,7 +94,7 @@ class ClientCredentialsTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_token_generator(self):
         m = "tests.flask.test_oauth2.oauth2_server:token_generator"
@@ -110,5 +110,5 @@ class ClientCredentialsTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("c-client_credentials.", resp["access_token"])
+        assert "access_token" in resp
+        assert "c-client_credentials." in resp["access_token"]

--- a/tests/flask/test_oauth2/test_client_registration_endpoint.py
+++ b/tests/flask/test_oauth2/test_client_registration_endpoint.py
@@ -62,14 +62,14 @@ class OAuthClientRegistrationTest(TestCase):
         self.prepare_data()
         rv = self.client.post("/create_client", json={})
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "access_denied")
+        assert resp["error"] == "access_denied"
 
     def test_invalid_request(self):
         self.prepare_data()
         headers = {"Authorization": "bearer abc"}
         rv = self.client.post("/create_client", json={}, headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
     def test_create_client(self):
         self.prepare_data()
@@ -77,8 +77,8 @@ class OAuthClientRegistrationTest(TestCase):
         body = {"client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
     def test_software_statement(self):
         payload = {"software_id": "uuid-123", "client_name": "Authlib"}
@@ -91,8 +91,8 @@ class OAuthClientRegistrationTest(TestCase):
         headers = {"Authorization": "bearer abc"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
     def test_no_public_key(self):
         class ClientRegistrationEndpoint2(ClientRegistrationEndpoint):
@@ -112,7 +112,7 @@ class OAuthClientRegistrationTest(TestCase):
         headers = {"Authorization": "bearer abc"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "unapproved_software_statement")
+        assert resp["error"] in "unapproved_software_statement"
 
     def test_scopes_supported(self):
         metadata = {"scopes_supported": ["profile", "email"]}
@@ -122,13 +122,13 @@ class OAuthClientRegistrationTest(TestCase):
         body = {"scope": "profile email", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
         body = {"scope": "profile email address", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_response_types_supported(self):
         metadata = {"response_types_supported": ["code", "code id_token"]}
@@ -138,8 +138,8 @@ class OAuthClientRegistrationTest(TestCase):
         body = {"response_types": ["code"], "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
         # The items order should not matter
         # Extension response types MAY contain a space-delimited (%x20) list of
@@ -158,13 +158,13 @@ class OAuthClientRegistrationTest(TestCase):
         body = {"client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
         body = {"response_types": ["code", "token"], "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_grant_types_supported(self):
         metadata = {"grant_types_supported": ["authorization_code", "password"]}
@@ -174,8 +174,8 @@ class OAuthClientRegistrationTest(TestCase):
         body = {"grant_types": ["password"], "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
         # https://www.rfc-editor.org/rfc/rfc7591.html#section-2
         # If omitted, the default behavior is that the client will use only
@@ -183,13 +183,13 @@ class OAuthClientRegistrationTest(TestCase):
         body = {"client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
         body = {"grant_types": ["client_credentials"], "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_token_endpoint_auth_methods_supported(self):
         metadata = {"token_endpoint_auth_methods_supported": ["client_secret_basic"]}
@@ -202,13 +202,13 @@ class OAuthClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
         body = {"token_endpoint_auth_method": "none", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
 
 class OIDCClientRegistrationTest(TestCase):
@@ -245,9 +245,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["application_type"], "web")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["application_type"] == "web"
 
         # Default case
         # The default, if omitted, is that any algorithm supported by the OP and the RP MAY be used.
@@ -256,9 +256,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["application_type"], "web")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["application_type"] == "web"
 
         # Error case
         body = {
@@ -267,7 +267,7 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_token_endpoint_auth_signing_alg_supported(self):
         metadata = {
@@ -282,9 +282,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["token_endpoint_auth_signing_alg"], "ES256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["token_endpoint_auth_signing_alg"] == "ES256"
 
         # Default case
         # The default, if omitted, is that any algorithm supported by the OP and the RP MAY be used.
@@ -293,8 +293,8 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
 
         # Error case
         body = {
@@ -303,7 +303,7 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_subject_types_supported(self):
         metadata = {"subject_types_supported": ["public", "pairwise"]}
@@ -313,15 +313,15 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"subject_type": "public", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["subject_type"], "public")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["subject_type"] == "public"
 
         # Error case
         body = {"subject_type": "invalid", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_id_token_signing_alg_values_supported(self):
         metadata = {"id_token_signing_alg_values_supported": ["RS256", "ES256"]}
@@ -332,23 +332,23 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["id_token_signed_response_alg"], "RS256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["id_token_signed_response_alg"] == "RS256"
 
         # Nominal case
         body = {"id_token_signed_response_alg": "ES256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["id_token_signed_response_alg"], "ES256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["id_token_signed_response_alg"] == "ES256"
 
         # Error case
         body = {"id_token_signed_response_alg": "RS512", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_id_token_signing_alg_values_none(self):
         # The value none MUST NOT be used as the ID Token alg value unless the Client uses
@@ -387,32 +387,32 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertNotIn("id_token_encrypted_response_enc", resp)
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert "id_token_encrypted_response_enc" not in resp
 
         # If id_token_encrypted_response_alg is specified, the default
         # id_token_encrypted_response_enc value is A128CBC-HS256.
         body = {"id_token_encrypted_response_alg": "RS256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["id_token_encrypted_response_enc"], "A128CBC-HS256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["id_token_encrypted_response_enc"] == "A128CBC-HS256"
 
         # Nominal case
         body = {"id_token_encrypted_response_alg": "ES256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["id_token_encrypted_response_alg"], "ES256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["id_token_encrypted_response_alg"] == "ES256"
 
         # Error case
         body = {"id_token_encrypted_response_alg": "RS512", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_id_token_encryption_enc_values_supported(self):
         metadata = {
@@ -428,22 +428,22 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["id_token_encrypted_response_alg"], "RS256")
-        self.assertEqual(resp["id_token_encrypted_response_enc"], "A256GCM")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["id_token_encrypted_response_alg"] == "RS256"
+        assert resp["id_token_encrypted_response_enc"] == "A256GCM"
 
         # Error case: missing id_token_encrypted_response_alg
         body = {"id_token_encrypted_response_enc": "A256GCM", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
         # Error case: alg not in server metadata
         body = {"id_token_encrypted_response_enc": "A128GCM", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_userinfo_signing_alg_values_supported(self):
         metadata = {"userinfo_signing_alg_values_supported": ["RS256", "ES256"]}
@@ -453,15 +453,15 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"userinfo_signed_response_alg": "ES256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["userinfo_signed_response_alg"], "ES256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["userinfo_signed_response_alg"] == "ES256"
 
         # Error case
         body = {"userinfo_signed_response_alg": "RS512", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_userinfo_encryption_alg_values_supported(self):
         metadata = {"userinfo_encryption_alg_values_supported": ["RS256", "ES256"]}
@@ -471,15 +471,15 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"userinfo_encrypted_response_alg": "ES256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["userinfo_encrypted_response_alg"], "ES256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["userinfo_encrypted_response_alg"] == "ES256"
 
         # Error case
         body = {"userinfo_encrypted_response_alg": "RS512", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_userinfo_encryption_enc_values_supported(self):
         metadata = {
@@ -491,18 +491,18 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertNotIn("userinfo_encrypted_response_enc", resp)
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert "userinfo_encrypted_response_enc" not in resp
 
         # If userinfo_encrypted_response_alg is specified, the default
         # userinfo_encrypted_response_enc value is A128CBC-HS256.
         body = {"userinfo_encrypted_response_alg": "RS256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["userinfo_encrypted_response_enc"], "A128CBC-HS256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["userinfo_encrypted_response_enc"] == "A128CBC-HS256"
 
         # Nominal case
         body = {
@@ -512,22 +512,22 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["userinfo_encrypted_response_alg"], "RS256")
-        self.assertEqual(resp["userinfo_encrypted_response_enc"], "A256GCM")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["userinfo_encrypted_response_alg"] == "RS256"
+        assert resp["userinfo_encrypted_response_enc"] == "A256GCM"
 
         # Error case: no userinfo_encrypted_response_alg
         body = {"userinfo_encrypted_response_enc": "A256GCM", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
         # Error case: alg not in server metadata
         body = {"userinfo_encrypted_response_enc": "A128GCM", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_acr_values_supported(self):
         metadata = {
@@ -545,9 +545,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["default_acr_values"], ["urn:mace:incommon:iap:silver"])
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["default_acr_values"] == ["urn:mace:incommon:iap:silver"]
 
         # Error case
         body = {
@@ -559,7 +559,7 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_request_object_signing_alg_values_supported(self):
         metadata = {"request_object_signing_alg_values_supported": ["RS256", "ES256"]}
@@ -569,15 +569,15 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"request_object_signing_alg": "ES256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["request_object_signing_alg"], "ES256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["request_object_signing_alg"] == "ES256"
 
         # Error case
         body = {"request_object_signing_alg": "RS512", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_request_object_encryption_alg_values_supported(self):
         metadata = {
@@ -592,9 +592,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["request_object_encryption_alg"], "ES256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["request_object_encryption_alg"] == "ES256"
 
         # Error case
         body = {
@@ -603,7 +603,7 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_request_object_encryption_enc_values_supported(self):
         metadata = {
@@ -618,18 +618,18 @@ class OIDCClientRegistrationTest(TestCase):
         body = {"client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertNotIn("request_object_encryption_enc", resp)
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert "request_object_encryption_enc" not in resp
 
         # If request_object_encryption_alg is specified, the default
         # request_object_encryption_enc value is A128CBC-HS256.
         body = {"request_object_encryption_alg": "RS256", "client_name": "Authlib"}
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["request_object_encryption_enc"], "A128CBC-HS256")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["request_object_encryption_enc"] == "A128CBC-HS256"
 
         # Nominal case
         body = {
@@ -639,10 +639,10 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["request_object_encryption_alg"], "RS256")
-        self.assertEqual(resp["request_object_encryption_enc"], "A256GCM")
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["request_object_encryption_alg"] == "RS256"
+        assert resp["request_object_encryption_enc"] == "A256GCM"
 
         # Error case: missing request_object_encryption_alg
         body = {
@@ -651,7 +651,7 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
         # Error case: alg not in server metadata
         body = {
@@ -660,7 +660,7 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_require_auth_time(self):
         self.prepare_data()
@@ -671,9 +671,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["require_auth_time"], False)
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["require_auth_time"] is False
 
         # Nominal case
         body = {
@@ -682,9 +682,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["require_auth_time"], True)
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["require_auth_time"] is True
 
         # Error case
         body = {
@@ -693,7 +693,7 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"
 
     def test_redirect_uri(self):
         """RFC6749 indicate that fragments are forbidden in redirect_uri.
@@ -713,9 +713,9 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn("client_id", resp)
-        self.assertEqual(resp["client_name"], "Authlib")
-        self.assertEqual(resp["redirect_uris"], ["https://client.test"])
+        assert "client_id" in resp
+        assert resp["client_name"] == "Authlib"
+        assert resp["redirect_uris"] == ["https://client.test"]
 
         # Error case
         body = {
@@ -724,4 +724,4 @@ class OIDCClientRegistrationTest(TestCase):
         }
         rv = self.client.post("/create_client", json=body, headers=self.headers)
         resp = json.loads(rv.data)
-        self.assertIn(resp["error"], "invalid_client_metadata")
+        assert resp["error"] in "invalid_client_metadata"

--- a/tests/flask/test_oauth2/test_code_challenge.py
+++ b/tests/flask/test_oauth2/test_code_challenge.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import json
 
 from authlib.common.security import generate_token
@@ -61,7 +62,7 @@ class CodeChallengeTest(TestCase):
     def test_missing_code_challenge(self):
         self.prepare_data()
         rv = self.client.get(self.authorize_url + "&code_challenge_method=plain")
-        self.assertIn("Missing", rv.location)
+        assert "Missing" in rv.location
 
     def test_has_code_challenge(self):
         self.prepare_data()
@@ -69,34 +70,34 @@ class CodeChallengeTest(TestCase):
             self.authorize_url
             + "&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s"
         )
-        self.assertEqual(rv.data, b"ok")
+        assert rv.data == b"ok"
 
     def test_invalid_code_challenge(self):
         self.prepare_data()
         rv = self.client.get(
             self.authorize_url + "&code_challenge=abc&code_challenge_method=plain"
         )
-        self.assertIn("Invalid", rv.location)
+        assert "Invalid" in rv.location
 
     def test_invalid_code_challenge_method(self):
         self.prepare_data()
         suffix = "&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s&code_challenge_method=invalid"
         rv = self.client.get(self.authorize_url + suffix)
-        self.assertIn("Unsupported", rv.location)
+        assert "Unsupported" in rv.location
 
     def test_supported_code_challenge_method(self):
         self.prepare_data()
         suffix = "&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s&code_challenge_method=plain"
         rv = self.client.get(self.authorize_url + suffix)
-        self.assertEqual(rv.data, b"ok")
+        assert rv.data == b"ok"
 
     def test_trusted_client_without_code_challenge(self):
         self.prepare_data("client_secret_basic")
         rv = self.client.get(self.authorize_url)
-        self.assertEqual(rv.data, b"ok")
+        assert rv.data == b"ok"
 
         rv = self.client.post(self.authorize_url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
 
@@ -111,7 +112,7 @@ class CodeChallengeTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_missing_code_verifier(self):
         self.prepare_data()
@@ -120,7 +121,7 @@ class CodeChallengeTest(TestCase):
             + "&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s"
         )
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         code = params["code"]
@@ -133,7 +134,7 @@ class CodeChallengeTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("Missing", resp["error_description"])
+        assert "Missing" in resp["error_description"]
 
     def test_trusted_client_missing_code_verifier(self):
         self.prepare_data("client_secret_basic")
@@ -142,7 +143,7 @@ class CodeChallengeTest(TestCase):
             + "&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s"
         )
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         code = params["code"]
@@ -156,7 +157,7 @@ class CodeChallengeTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("Missing", resp["error_description"])
+        assert "Missing" in resp["error_description"]
 
     def test_plain_code_challenge_invalid(self):
         self.prepare_data()
@@ -165,7 +166,7 @@ class CodeChallengeTest(TestCase):
             + "&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s"
         )
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         code = params["code"]
@@ -179,7 +180,7 @@ class CodeChallengeTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("Invalid", resp["error_description"])
+        assert "Invalid" in resp["error_description"]
 
     def test_plain_code_challenge_failed(self):
         self.prepare_data()
@@ -188,7 +189,7 @@ class CodeChallengeTest(TestCase):
             + "&code_challenge=Zhs2POMonIVVHZteWfoU7cSXQSm0YjghikFGJSDI2_s"
         )
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         code = params["code"]
@@ -202,14 +203,14 @@ class CodeChallengeTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("failed", resp["error_description"])
+        assert "failed" in resp["error_description"]
 
     def test_plain_code_challenge_success(self):
         self.prepare_data()
         code_verifier = generate_token(48)
         url = self.authorize_url + "&code_challenge=" + code_verifier
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         code = params["code"]
@@ -223,7 +224,7 @@ class CodeChallengeTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_s256_code_challenge_success(self):
         self.prepare_data()
@@ -233,7 +234,7 @@ class CodeChallengeTest(TestCase):
         url += "&code_challenge_method=S256"
 
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         code = params["code"]
@@ -247,7 +248,7 @@ class CodeChallengeTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_not_implemented_code_challenge_method(self):
         self.prepare_data()
@@ -258,18 +259,17 @@ class CodeChallengeTest(TestCase):
         url += "&code_challenge_method=S128"
 
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         code = params["code"]
-        self.assertRaises(
-            RuntimeError,
-            self.client.post,
-            "/oauth/token",
-            data={
-                "grant_type": "authorization_code",
-                "code": code,
-                "code_verifier": generate_token(48),
-                "client_id": "code-client",
-            },
-        )
+        with pytest.raises(RuntimeError):
+            self.client.post(
+                "/oauth/token",
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "code_verifier": generate_token(48),
+                    "client_id": "code-client",
+                },
+            )

--- a/tests/flask/test_oauth2/test_device_code_grant.py
+++ b/tests/flask/test_oauth2/test_device_code_grant.py
@@ -111,7 +111,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
         rv = self.client.post(
             "/oauth/token",
@@ -122,7 +122,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
     def test_unauthorized_client(self):
         self.create_server()
@@ -135,7 +135,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         self.prepare_data(grant_type="password")
         rv = self.client.post(
@@ -147,7 +147,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert resp["error"] == "unauthorized_client"
 
     def test_invalid_client(self):
         self.create_server()
@@ -161,7 +161,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_expired_token(self):
         self.create_server()
@@ -175,7 +175,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "expired_token")
+        assert resp["error"] == "expired_token"
 
     def test_denied_by_user(self):
         self.create_server()
@@ -189,7 +189,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "access_denied")
+        assert resp["error"] == "access_denied"
 
     def test_authorization_pending(self):
         self.create_server()
@@ -203,7 +203,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "authorization_pending")
+        assert resp["error"] == "authorization_pending"
 
     def test_get_access_token(self):
         self.create_server()
@@ -217,7 +217,7 @@ class DeviceCodeGrantTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
 
 class DeviceAuthorizationEndpoint(_DeviceAuthorizationEndpoint):
@@ -244,9 +244,9 @@ class DeviceAuthorizationEndpointTest(TestCase):
     def test_missing_client_id(self):
         self.create_server()
         rv = self.client.post("/device_authorize", data={"scope": "profile"})
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_create_authorization_response(self):
         self.create_server()
@@ -263,12 +263,12 @@ class DeviceAuthorizationEndpointTest(TestCase):
                 "client_id": "client",
             },
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertIn("device_code", resp)
-        self.assertIn("user_code", resp)
-        self.assertEqual(resp["verification_uri"], "https://example.com/activate")
-        self.assertEqual(
-            resp["verification_uri_complete"],
-            "https://example.com/activate?user_code=" + resp["user_code"],
+        assert "device_code" in resp
+        assert "user_code" in resp
+        assert resp["verification_uri"] == "https://example.com/activate"
+        assert (
+            resp["verification_uri_complete"]
+            == "https://example.com/activate?user_code=" + resp["user_code"]
         )

--- a/tests/flask/test_oauth2/test_implicit_grant.py
+++ b/tests/flask/test_oauth2/test_implicit_grant.py
@@ -46,41 +46,41 @@ class ImplicitTest(TestCase):
     def test_get_authorize(self):
         self.prepare_data()
         rv = self.client.get(self.authorize_url)
-        self.assertEqual(rv.data, b"ok")
+        assert rv.data == b"ok"
 
     def test_confidential_client(self):
         self.prepare_data(True)
         rv = self.client.get(self.authorize_url)
-        self.assertIn(b"invalid_client", rv.data)
+        assert b"invalid_client" in rv.data
 
     def test_unsupported_client(self):
         self.prepare_data(response_type="code")
         rv = self.client.get(self.authorize_url)
-        self.assertIn("unauthorized_client", rv.location)
+        assert "unauthorized_client" in rv.location
 
     def test_invalid_authorize(self):
         self.prepare_data()
         rv = self.client.post(self.authorize_url)
-        self.assertIn("#error=access_denied", rv.location)
+        assert "#error=access_denied" in rv.location
 
         self.server.scopes_supported = ["profile"]
         rv = self.client.post(self.authorize_url + "&scope=invalid")
-        self.assertIn("#error=invalid_scope", rv.location)
+        assert "#error=invalid_scope" in rv.location
 
     def test_authorize_token(self):
         self.prepare_data()
         rv = self.client.post(self.authorize_url, data={"user_id": "1"})
-        self.assertIn("access_token=", rv.location)
+        assert "access_token=" in rv.location
 
         url = self.authorize_url + "&state=bar&scope=profile"
         rv = self.client.post(url, data={"user_id": "1"})
-        self.assertIn("access_token=", rv.location)
-        self.assertIn("state=bar", rv.location)
-        self.assertIn("scope=profile", rv.location)
+        assert "access_token=" in rv.location
+        assert "state=bar" in rv.location
+        assert "scope=profile" in rv.location
 
     def test_token_generator(self):
         m = "tests.flask.test_oauth2.oauth2_server:token_generator"
         self.app.config.update({"OAUTH2_ACCESS_TOKEN_GENERATOR": m})
         self.prepare_data()
         rv = self.client.post(self.authorize_url, data={"user_id": "1"})
-        self.assertIn("access_token=i-implicit.1.", rv.location)
+        assert "access_token=i-implicit.1." in rv.location

--- a/tests/flask/test_oauth2/test_introspection_endpoint.py
+++ b/tests/flask/test_oauth2/test_introspection_endpoint.py
@@ -80,29 +80,29 @@ class IntrospectTokenTest(TestCase):
         self.prepare_data()
         rv = self.client.post("/oauth/introspect")
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = {"Authorization": "invalid token_string"}
         rv = self.client.post("/oauth/introspect", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("invalid-client", "introspect-secret")
         rv = self.client.post("/oauth/introspect", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("introspect-client", "invalid-secret")
         rv = self.client.post("/oauth/introspect", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_invalid_token(self):
         self.prepare_data()
         headers = self.create_basic_header("introspect-client", "introspect-secret")
         rv = self.client.post("/oauth/introspect", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
         rv = self.client.post(
             "/oauth/introspect",
@@ -112,7 +112,7 @@ class IntrospectTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
         rv = self.client.post(
             "/oauth/introspect",
@@ -123,7 +123,7 @@ class IntrospectTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_token_type")
+        assert resp["error"] == "unsupported_token_type"
 
         rv = self.client.post(
             "/oauth/introspect",
@@ -133,7 +133,7 @@ class IntrospectTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["active"], False)
+        assert resp["active"] is False
 
         rv = self.client.post(
             "/oauth/introspect",
@@ -144,7 +144,7 @@ class IntrospectTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["active"], False)
+        assert resp["active"] is False
 
     def test_introspect_token_with_hint(self):
         self.prepare_data()
@@ -158,9 +158,9 @@ class IntrospectTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertEqual(resp["client_id"], "introspect-client")
+        assert resp["client_id"] == "introspect-client"
 
     def test_introspect_token_without_hint(self):
         self.prepare_data()
@@ -173,6 +173,6 @@ class IntrospectTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertEqual(resp["client_id"], "introspect-client")
+        assert resp["client_id"] == "introspect-client"

--- a/tests/flask/test_oauth2/test_jwt_access_token.py
+++ b/tests/flask/test_oauth2/test_jwt_access_token.py
@@ -419,27 +419,27 @@ class JWTAccessTokenResourceServerTest(TestCase):
 
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "foo")
+        assert resp["username"] == "foo"
 
     def test_missing_authorization(self):
         rv = self.client.get("/protected")
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "missing_authorization")
+        assert resp["error"] == "missing_authorization"
 
     def test_unsupported_token_type(self):
         headers = {"Authorization": "invalid token"}
         rv = self.client.get("/protected", headers=headers)
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_token_type")
+        assert resp["error"] == "unsupported_token_type"
 
     def test_invalid_token(self):
         headers = {"Authorization": "Bearer invalid"}
         rv = self.client.get("/protected", headers=headers)
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
     def test_typ(self):
         """The resource server MUST verify that the 'typ' header value is 'at+jwt' or
@@ -450,7 +450,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "foo")
+        assert resp["username"] == "foo"
 
         access_token = create_access_token(
             self.claims, self.jwks, typ="application/at+jwt"
@@ -459,14 +459,14 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "foo")
+        assert resp["username"] == "foo"
 
         access_token = create_access_token(self.claims, self.jwks, typ="invalid")
 
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
     def test_missing_required_claims(self):
         required_claims = ["iss", "exp", "aud", "sub", "client_id", "iat", "jti"]
@@ -480,7 +480,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
             headers = {"Authorization": f"Bearer {access_token}"}
             rv = self.client.get("/protected", headers=headers)
             resp = json.loads(rv.data)
-            self.assertEqual(resp["error"], "invalid_token")
+            assert resp["error"] == "invalid_token"
 
     def test_invalid_iss(self):
         """The issuer identifier for the authorization server (which is typically obtained
@@ -492,7 +492,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
     def test_invalid_aud(self):
         """The resource server MUST validate that the 'aud' claim contains a resource
@@ -506,7 +506,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
     def test_invalid_exp(self):
         """The current time MUST be before the time represented by the 'exp' claim.
@@ -519,7 +519,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
     def test_scope_restriction(self):
         """If an authorization request includes a scope parameter, the corresponding
@@ -535,11 +535,11 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "foo")
+        assert resp["username"] == "foo"
 
         rv = self.client.get("/protected-by-scope", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "insufficient_scope")
+        assert resp["error"] == "insufficient_scope"
 
     def test_entitlements_restriction(self):
         """Many authorization servers embed authorization attributes that go beyond the
@@ -562,11 +562,11 @@ class JWTAccessTokenResourceServerTest(TestCase):
             headers = {"Authorization": f"Bearer {access_token}"}
             rv = self.client.get("/protected", headers=headers)
             resp = json.loads(rv.data)
-            self.assertEqual(resp["username"], "foo")
+            assert resp["username"] == "foo"
 
             rv = self.client.get(f"/protected-by-{claim}", headers=headers)
             resp = json.loads(rv.data)
-            self.assertEqual(resp["error"], "invalid_token")
+            assert resp["error"] == "invalid_token"
 
     def test_extra_attributes(self):
         """Authorization servers MAY return arbitrary attributes not defined in any
@@ -580,7 +580,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["token"]["email"], "user@example.org")
+        assert resp["token"]["email"] == "user@example.org"
 
     def test_invalid_auth_time(self):
         self.claims["auth_time"] = "invalid-auth-time"
@@ -589,7 +589,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
     def test_invalid_amr(self):
         self.claims["amr"] = "invalid-amr"
@@ -598,7 +598,7 @@ class JWTAccessTokenResourceServerTest(TestCase):
         headers = {"Authorization": f"Bearer {access_token}"}
         rv = self.client.get("/protected", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
 
 class JWTAccessTokenIntrospectionTest(TestCase):
@@ -629,15 +629,15 @@ class JWTAccessTokenIntrospectionTest(TestCase):
         rv = self.client.post(
             "/oauth/introspect", data={"token": self.access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertTrue(resp["active"])
-        self.assertEqual(resp["client_id"], self.oauth_client.client_id)
-        self.assertEqual(resp["token_type"], "Bearer")
-        self.assertEqual(resp["scope"], self.oauth_client.scope)
-        self.assertEqual(resp["sub"], self.user.id)
-        self.assertEqual(resp["aud"], [self.resource_server])
-        self.assertEqual(resp["iss"], self.issuer)
+        assert resp["active"]
+        assert resp["client_id"] == self.oauth_client.client_id
+        assert resp["token_type"] == "Bearer"
+        assert resp["scope"] == self.oauth_client.scope
+        assert resp["sub"] == self.user.id
+        assert resp["aud"] == [self.resource_server]
+        assert resp["iss"] == self.issuer
 
     def test_introspection_username(self):
         self.introspection_endpoint.get_username = lambda user_id: db.session.get(
@@ -650,10 +650,10 @@ class JWTAccessTokenIntrospectionTest(TestCase):
         rv = self.client.post(
             "/oauth/introspect", data={"token": self.access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertTrue(resp["active"])
-        self.assertEqual(resp["username"], self.user.username)
+        assert resp["active"]
+        assert resp["username"] == self.user.username
 
     def test_non_access_token_skipped(self):
         class MyIntrospectionEndpoint(IntrospectionEndpoint):
@@ -672,9 +672,9 @@ class JWTAccessTokenIntrospectionTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertFalse(resp["active"])
+        assert not resp["active"]
 
     def test_access_token_non_jwt_skipped(self):
         class MyIntrospectionEndpoint(IntrospectionEndpoint):
@@ -692,9 +692,9 @@ class JWTAccessTokenIntrospectionTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertFalse(resp["active"])
+        assert not resp["active"]
 
     def test_permission_denied(self):
         self.introspection_endpoint.check_permission = lambda *args: False
@@ -705,9 +705,9 @@ class JWTAccessTokenIntrospectionTest(TestCase):
         rv = self.client.post(
             "/oauth/introspect", data={"token": self.access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertFalse(resp["active"])
+        assert not resp["active"]
 
     def test_token_expired(self):
         self.claims["exp"] = time.time() - 3600
@@ -718,9 +718,9 @@ class JWTAccessTokenIntrospectionTest(TestCase):
         rv = self.client.post(
             "/oauth/introspect", data={"token": access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertFalse(resp["active"])
+        assert not resp["active"]
 
     def test_introspection_different_issuer(self):
         class MyIntrospectionEndpoint(IntrospectionEndpoint):
@@ -737,9 +737,9 @@ class JWTAccessTokenIntrospectionTest(TestCase):
         rv = self.client.post(
             "/oauth/introspect", data={"token": access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertFalse(resp["active"])
+        assert not resp["active"]
 
     def test_introspection_invalid_claim(self):
         self.claims["exp"] = "invalid"
@@ -750,9 +750,9 @@ class JWTAccessTokenIntrospectionTest(TestCase):
         rv = self.client.post(
             "/oauth/introspect", data={"token": access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
 
 class JWTAccessTokenRevocationTest(TestCase):
@@ -783,9 +783,9 @@ class JWTAccessTokenRevocationTest(TestCase):
         rv = self.client.post(
             "/oauth/revoke", data={"token": self.access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_token_type")
+        assert resp["error"] == "unsupported_token_type"
 
     def test_non_access_token_skipped(self):
         class MyRevocationEndpoint(RevocationEndpoint):
@@ -804,9 +804,9 @@ class JWTAccessTokenRevocationTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertEqual(resp, {})
+        assert resp == {}
 
     def test_access_token_non_jwt_skipped(self):
         class MyRevocationEndpoint(RevocationEndpoint):
@@ -824,9 +824,9 @@ class JWTAccessTokenRevocationTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertEqual(resp, {})
+        assert resp == {}
 
     def test_revocation_different_issuer(self):
         self.claims["iss"] = "different-issuer"
@@ -838,6 +838,6 @@ class JWTAccessTokenRevocationTest(TestCase):
         rv = self.client.post(
             "/oauth/revoke", data={"token": access_token}, headers=headers
         )
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_token_type")
+        assert resp["error"] == "unsupported_token_type"

--- a/tests/flask/test_oauth2/test_jwt_bearer_client_auth.py
+++ b/tests/flask/test_oauth2/test_jwt_bearer_client_auth.py
@@ -67,7 +67,7 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_invalid_jwt(self):
         self.prepare_data(JWTBearerClientAssertion.CLIENT_AUTH_METHOD)
@@ -85,7 +85,7 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_not_found_client(self):
         self.prepare_data(JWTBearerClientAssertion.CLIENT_AUTH_METHOD)
@@ -103,7 +103,7 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_not_supported_auth_method(self):
         self.prepare_data("invalid")
@@ -120,7 +120,7 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_client_secret_jwt(self):
         self.prepare_data(JWTBearerClientAssertion.CLIENT_AUTH_METHOD)
@@ -139,7 +139,7 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_private_key_jwt(self):
         self.prepare_data(JWTBearerClientAssertion.CLIENT_AUTH_METHOD)
@@ -157,7 +157,7 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_not_validate_jti(self):
         self.prepare_data(JWTBearerClientAssertion.CLIENT_AUTH_METHOD, False)
@@ -175,4 +175,4 @@ class ClientCredentialsTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp

--- a/tests/flask/test_oauth2/test_jwt_bearer_grant.py
+++ b/tests/flask/test_oauth2/test_jwt_bearer_grant.py
@@ -61,8 +61,8 @@ class JWTBearerGrantTest(TestCase):
             "/oauth/token", data={"grant_type": JWTBearerGrant.GRANT_TYPE}
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
-        self.assertIn("assertion", resp["error_description"])
+        assert resp["error"] == "invalid_request"
+        assert "assertion" in resp["error_description"]
 
     def test_invalid_assertion(self):
         self.prepare_data()
@@ -78,7 +78,7 @@ class JWTBearerGrantTest(TestCase):
             data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_grant")
+        assert resp["error"] == "invalid_grant"
 
     def test_authorize_token(self):
         self.prepare_data()
@@ -94,7 +94,7 @@ class JWTBearerGrantTest(TestCase):
             data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_unauthorized_client(self):
         self.prepare_data("password")
@@ -110,7 +110,7 @@ class JWTBearerGrantTest(TestCase):
             data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert resp["error"] == "unauthorized_client"
 
     def test_token_generator(self):
         m = "tests.flask.test_oauth2.oauth2_server:token_generator"
@@ -128,8 +128,8 @@ class JWTBearerGrantTest(TestCase):
             data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("j-", resp["access_token"])
+        assert "access_token" in resp
+        assert "j-" in resp["access_token"]
 
     def test_jwt_bearer_token_generator(self):
         private_key = read_file_path("jwks_private.json")
@@ -146,5 +146,5 @@ class JWTBearerGrantTest(TestCase):
             data={"grant_type": JWTBearerGrant.GRANT_TYPE, "assertion": assertion},
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertEqual(resp["access_token"].count("."), 2)
+        assert "access_token" in resp
+        assert resp["access_token"].count(".") == 2

--- a/tests/flask/test_oauth2/test_oauth2_server.py
+++ b/tests/flask/test_oauth2/test_oauth2_server.py
@@ -66,10 +66,10 @@ class AuthorizationTest(TestCase):
         create_authorization_server(self.app)
         authorize_url = "/oauth/authorize?response_type=token&client_id=implicit-client"
         rv = self.client.get(authorize_url)
-        self.assertIn(b"unsupported_response_type", rv.data)
+        assert b"unsupported_response_type" in rv.data
 
         rv = self.client.post(authorize_url, data={"user_id": "1"})
-        self.assertNotEqual(rv.status, 200)
+        assert rv.status != 200
 
         rv = self.client.post(
             "/oauth/token",
@@ -79,7 +79,7 @@ class AuthorizationTest(TestCase):
             },
         )
         data = json.loads(rv.data)
-        self.assertEqual(data["error"], "unsupported_grant_type")
+        assert data["error"] == "unsupported_grant_type"
 
 
 class ResourceTest(TestCase):
@@ -122,21 +122,21 @@ class ResourceTest(TestCase):
         self.prepare_data()
 
         rv = self.client.get("/user")
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "missing_authorization")
+        assert resp["error"] == "missing_authorization"
 
         headers = {"Authorization": "invalid token"}
         rv = self.client.get("/user", headers=headers)
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_token_type")
+        assert resp["error"] == "unsupported_token_type"
 
         headers = self.create_bearer_header("invalid")
         rv = self.client.get("/user", headers=headers)
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
     def test_expired_token(self):
         self.prepare_data()
@@ -144,21 +144,21 @@ class ResourceTest(TestCase):
         headers = self.create_bearer_header("a1")
 
         rv = self.client.get("/user", headers=headers)
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_token")
+        assert resp["error"] == "invalid_token"
 
         rv = self.client.get("/acquire", headers=headers)
-        self.assertEqual(rv.status_code, 401)
+        assert rv.status_code == 401
 
     def test_insufficient_token(self):
         self.prepare_data()
         self.create_token()
         headers = self.create_bearer_header("a1")
         rv = self.client.get("/user/email", headers=headers)
-        self.assertEqual(rv.status_code, 403)
+        assert rv.status_code == 403
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "insufficient_scope")
+        assert resp["error"] == "insufficient_scope"
 
     def test_access_resource(self):
         self.prepare_data()
@@ -167,38 +167,38 @@ class ResourceTest(TestCase):
 
         rv = self.client.get("/user", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "foo")
+        assert resp["username"] == "foo"
 
         rv = self.client.get("/acquire", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "foo")
+        assert resp["username"] == "foo"
 
         rv = self.client.get("/info", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["status"], "ok")
+        assert resp["status"] == "ok"
 
     def test_scope_operator(self):
         self.prepare_data()
         self.create_token()
         headers = self.create_bearer_header("a1")
         rv = self.client.get("/operator-and", headers=headers)
-        self.assertEqual(rv.status_code, 403)
+        assert rv.status_code == 403
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "insufficient_scope")
+        assert resp["error"] == "insufficient_scope"
 
         rv = self.client.get("/operator-or", headers=headers)
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
 
     def test_optional_token(self):
         self.prepare_data()
         rv = self.client.get("/optional")
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "anonymous")
+        assert resp["username"] == "anonymous"
 
         self.create_token()
         headers = self.create_bearer_header("a1")
         rv = self.client.get("/optional", headers=headers)
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
         resp = json.loads(rv.data)
-        self.assertEqual(resp["username"], "foo")
+        assert resp["username"] == "foo"

--- a/tests/flask/test_oauth2/test_openid_code_grant.py
+++ b/tests/flask/test_oauth2/test_openid_code_grant.py
@@ -96,10 +96,10 @@ class OpenIDCodeTest(BaseTestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
-        self.assertEqual(params["state"], "bar")
+        assert params["state"] == "bar"
 
         code = params["code"]
         headers = self.create_basic_header("code-client", "code-secret")
@@ -113,8 +113,8 @@ class OpenIDCodeTest(BaseTestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("id_token", resp)
+        assert "access_token" in resp
+        assert "id_token" in resp
 
         claims = jwt.decode(
             resp["id_token"],
@@ -140,10 +140,10 @@ class OpenIDCodeTest(BaseTestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
-        self.assertEqual(params["state"], "bar")
+        assert params["state"] == "bar"
 
         code = params["code"]
         headers = self.create_basic_header("code-client", "code-secret")
@@ -157,8 +157,8 @@ class OpenIDCodeTest(BaseTestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertNotIn("id_token", resp)
+        assert "access_token" in resp
+        assert "id_token" not in resp
 
     def test_require_nonce(self):
         self.prepare_data(require_nonce=True)
@@ -174,8 +174,8 @@ class OpenIDCodeTest(BaseTestCase):
             },
         )
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
-        self.assertEqual(params["error"], "invalid_request")
-        self.assertEqual(params["error_description"], "Missing 'nonce' in request.")
+        assert params["error"] == "invalid_request"
+        assert params["error_description"] == "Missing 'nonce' in request."
 
     def test_nonce_replay(self):
         self.prepare_data()
@@ -189,10 +189,10 @@ class OpenIDCodeTest(BaseTestCase):
             "redirect_uri": "https://a.b",
         }
         rv = self.client.post("/oauth/authorize", data=data)
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         rv = self.client.post("/oauth/authorize", data=data)
-        self.assertIn("error=", rv.location)
+        assert "error=" in rv.location
 
     def test_prompt(self):
         self.prepare_data()
@@ -206,19 +206,19 @@ class OpenIDCodeTest(BaseTestCase):
         ]
         query = url_encode(params)
         rv = self.client.get("/oauth/authorize?" + query)
-        self.assertEqual(rv.data, b"login")
+        assert rv.data == b"login"
 
         query = url_encode(params + [("user_id", "1")])
         rv = self.client.get("/oauth/authorize?" + query)
-        self.assertEqual(rv.data, b"ok")
+        assert rv.data == b"ok"
 
         query = url_encode(params + [("prompt", "login")])
         rv = self.client.get("/oauth/authorize?" + query)
-        self.assertEqual(rv.data, b"login")
+        assert rv.data == b"login"
 
         query = url_encode(params + [("user_id", "1"), ("prompt", "login")])
         rv = self.client.get("/oauth/authorize?" + query)
-        self.assertEqual(rv.data, b"login")
+        assert rv.data == b"login"
 
     def test_prompt_none_not_logged(self):
         self.prepare_data()
@@ -235,8 +235,8 @@ class OpenIDCodeTest(BaseTestCase):
         rv = self.client.get("/oauth/authorize?" + query)
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
-        self.assertEqual(params["error"], "login_required")
-        self.assertEqual(params["state"], "bar")
+        assert params["error"] == "login_required"
+        assert params["state"] == "bar"
 
 
 class RSAOpenIDCodeTest(BaseTestCase):
@@ -266,10 +266,10 @@ class RSAOpenIDCodeTest(BaseTestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("code=", rv.location)
+        assert "code=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
-        self.assertEqual(params["state"], "bar")
+        assert params["state"] == "bar"
 
         code = params["code"]
         headers = self.create_basic_header("code-client", "code-secret")
@@ -283,8 +283,8 @@ class RSAOpenIDCodeTest(BaseTestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("id_token", resp)
+        assert "access_token" in resp
+        assert "id_token" in resp
 
         claims = jwt.decode(
             resp["id_token"],

--- a/tests/flask/test_oauth2/test_openid_hybrid_grant.py
+++ b/tests/flask/test_oauth2/test_openid_hybrid_grant.py
@@ -102,7 +102,7 @@ class OpenIDCodeTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         rv = self.client.post(
             "/oauth/authorize",
@@ -117,7 +117,7 @@ class OpenIDCodeTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_require_nonce(self):
         self.prepare_data()
@@ -132,8 +132,8 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("error=invalid_request", rv.location)
-        self.assertIn("nonce", rv.location)
+        assert "error=invalid_request" in rv.location
+        assert "nonce" in rv.location
 
     def test_invalid_response_type(self):
         self.prepare_data()
@@ -150,7 +150,7 @@ class OpenIDCodeTest(TestCase):
             },
         )
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
-        self.assertEqual(params["error"], "unsupported_response_type")
+        assert params["error"] == "unsupported_response_type"
 
     def test_invalid_scope(self):
         self.prepare_data()
@@ -166,7 +166,7 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("error=invalid_scope", rv.location)
+        assert "error=invalid_scope" in rv.location
 
     def test_access_denied(self):
         self.prepare_data()
@@ -181,7 +181,7 @@ class OpenIDCodeTest(TestCase):
                 "redirect_uri": "https://a.b",
             },
         )
-        self.assertIn("error=access_denied", rv.location)
+        assert "error=access_denied" in rv.location
 
     def test_code_access_token(self):
         self.prepare_data()
@@ -197,12 +197,12 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("code=", rv.location)
-        self.assertIn("access_token=", rv.location)
-        self.assertNotIn("id_token=", rv.location)
+        assert "code=" in rv.location
+        assert "access_token=" in rv.location
+        assert "id_token=" not in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).fragment))
-        self.assertEqual(params["state"], "bar")
+        assert params["state"] == "bar"
 
         code = params["code"]
         headers = self.create_basic_header("hybrid-client", "hybrid-secret")
@@ -216,8 +216,8 @@ class OpenIDCodeTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("id_token", resp)
+        assert "access_token" in resp
+        assert "id_token" in resp
 
     def test_code_id_token(self):
         self.prepare_data()
@@ -233,12 +233,12 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("code=", rv.location)
-        self.assertIn("id_token=", rv.location)
-        self.assertNotIn("access_token=", rv.location)
+        assert "code=" in rv.location
+        assert "id_token=" in rv.location
+        assert "access_token=" not in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).fragment))
-        self.assertEqual(params["state"], "bar")
+        assert params["state"] == "bar"
 
         params["nonce"] = "abc"
         params["client_id"] = "hybrid-client"
@@ -256,8 +256,8 @@ class OpenIDCodeTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("id_token", resp)
+        assert "access_token" in resp
+        assert "id_token" in resp
 
     def test_code_id_token_access_token(self):
         self.prepare_data()
@@ -273,12 +273,12 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("code=", rv.location)
-        self.assertIn("id_token=", rv.location)
-        self.assertIn("access_token=", rv.location)
+        assert "code=" in rv.location
+        assert "id_token=" in rv.location
+        assert "access_token=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).fragment))
-        self.assertEqual(params["state"], "bar")
+        assert params["state"] == "bar"
         self.validate_claims(params["id_token"], params)
 
         code = params["code"]
@@ -293,8 +293,8 @@ class OpenIDCodeTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("id_token", resp)
+        assert "access_token" in resp
+        assert "id_token" in resp
 
     def test_response_mode_query(self):
         self.prepare_data()
@@ -311,12 +311,12 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("code=", rv.location)
-        self.assertIn("id_token=", rv.location)
-        self.assertIn("access_token=", rv.location)
+        assert "code=" in rv.location
+        assert "id_token=" in rv.location
+        assert "access_token=" in rv.location
 
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
-        self.assertEqual(params["state"], "bar")
+        assert params["state"] == "bar"
 
     def test_response_mode_form_post(self):
         self.prepare_data()
@@ -333,6 +333,6 @@ class OpenIDCodeTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn(b'name="code"', rv.data)
-        self.assertIn(b'name="id_token"', rv.data)
-        self.assertIn(b'name="access_token"', rv.data)
+        assert b'name="code"' in rv.data
+        assert b'name="id_token"' in rv.data
+        assert b'name="access_token"' in rv.data

--- a/tests/flask/test_oauth2/test_openid_implict_grant.py
+++ b/tests/flask/test_oauth2/test_openid_implict_grant.py
@@ -73,8 +73,8 @@ class ImplicitTest(TestCase):
                 },
             )
         )
-        self.assertIn("error=invalid_request", rv.location)
-        self.assertIn("nonce", rv.location)
+        assert "error=invalid_request" in rv.location
+        assert "nonce" in rv.location
 
     def test_require_nonce(self):
         self.prepare_data()
@@ -89,8 +89,8 @@ class ImplicitTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("error=invalid_request", rv.location)
-        self.assertIn("nonce", rv.location)
+        assert "error=invalid_request" in rv.location
+        assert "nonce" in rv.location
 
     def test_missing_openid_in_scope(self):
         self.prepare_data()
@@ -106,7 +106,7 @@ class ImplicitTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("error=invalid_scope", rv.location)
+        assert "error=invalid_scope" in rv.location
 
     def test_denied(self):
         self.prepare_data()
@@ -121,7 +121,7 @@ class ImplicitTest(TestCase):
                 "redirect_uri": "https://a.b/c",
             },
         )
-        self.assertIn("error=access_denied", rv.location)
+        assert "error=access_denied" in rv.location
 
     def test_authorize_access_token(self):
         self.prepare_data()
@@ -137,9 +137,9 @@ class ImplicitTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("access_token=", rv.location)
-        self.assertIn("id_token=", rv.location)
-        self.assertIn("state=bar", rv.location)
+        assert "access_token=" in rv.location
+        assert "id_token=" in rv.location
+        assert "state=bar" in rv.location
         params = dict(url_decode(urlparse.urlparse(rv.location).fragment))
         self.validate_claims(params["id_token"], params)
 
@@ -157,8 +157,8 @@ class ImplicitTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("id_token=", rv.location)
-        self.assertIn("state=bar", rv.location)
+        assert "id_token=" in rv.location
+        assert "state=bar" in rv.location
         params = dict(url_decode(urlparse.urlparse(rv.location).fragment))
         self.validate_claims(params["id_token"], params)
 
@@ -177,8 +177,8 @@ class ImplicitTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn("id_token=", rv.location)
-        self.assertIn("state=bar", rv.location)
+        assert "id_token=" in rv.location
+        assert "state=bar" in rv.location
         params = dict(url_decode(urlparse.urlparse(rv.location).query))
         self.validate_claims(params["id_token"], params)
 
@@ -197,5 +197,5 @@ class ImplicitTest(TestCase):
                 "user_id": "1",
             },
         )
-        self.assertIn(b'name="id_token"', rv.data)
-        self.assertIn(b'name="state"', rv.data)
+        assert b'name="id_token"' in rv.data
+        assert b'name="state"' in rv.data

--- a/tests/flask/test_oauth2/test_password_grant.py
+++ b/tests/flask/test_oauth2/test_password_grant.py
@@ -67,7 +67,7 @@ class PasswordTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("password-client", "invalid-secret")
         rv = self.client.post(
@@ -80,7 +80,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_invalid_scope(self):
         self.prepare_data()
@@ -97,7 +97,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_scope")
+        assert resp["error"] == "invalid_scope"
 
     def test_invalid_request(self):
         self.prepare_data()
@@ -113,7 +113,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_grant_type")
+        assert resp["error"] == "unsupported_grant_type"
 
         rv = self.client.post(
             "/oauth/token",
@@ -123,7 +123,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
         rv = self.client.post(
             "/oauth/token",
@@ -134,7 +134,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
         rv = self.client.post(
             "/oauth/token",
@@ -146,7 +146,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
     def test_invalid_grant_type(self):
         self.prepare_data(grant_type="invalid")
@@ -161,7 +161,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert resp["error"] == "unauthorized_client"
 
     def test_authorize_token(self):
         self.prepare_data()
@@ -176,7 +176,7 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_token_generator(self):
         m = "tests.flask.test_oauth2.oauth2_server:token_generator"
@@ -193,8 +193,8 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("p-password.1.", resp["access_token"])
+        assert "access_token" in resp
+        assert "p-password.1." in resp["access_token"]
 
     def test_custom_expires_in(self):
         self.app.config.update({"OAUTH2_TOKEN_EXPIRES_IN": {"password": 1800}})
@@ -210,8 +210,8 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertEqual(resp["expires_in"], 1800)
+        assert "access_token" in resp
+        assert resp["expires_in"] == 1800
 
     def test_id_token_extension(self):
         self.prepare_data(extensions=[IDToken()])
@@ -227,5 +227,5 @@ class PasswordTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("id_token", resp)
+        assert "access_token" in resp
+        assert "id_token" in resp

--- a/tests/flask/test_oauth2/test_refresh_token.py
+++ b/tests/flask/test_oauth2/test_refresh_token.py
@@ -75,7 +75,7 @@ class RefreshTokenTest(TestCase):
             },
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("invalid-client", "refresh-secret")
         rv = self.client.post(
@@ -87,7 +87,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("refresh-client", "invalid-secret")
         rv = self.client.post(
@@ -99,7 +99,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_invalid_refresh_token(self):
         self.prepare_data()
@@ -112,8 +112,8 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
-        self.assertIn("Missing", resp["error_description"])
+        assert resp["error"] == "invalid_request"
+        assert "Missing" in resp["error_description"]
 
         rv = self.client.post(
             "/oauth/token",
@@ -124,7 +124,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_grant")
+        assert resp["error"] == "invalid_grant"
 
     def test_invalid_scope(self):
         self.prepare_data()
@@ -140,7 +140,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_scope")
+        assert resp["error"] == "invalid_scope"
 
     def test_invalid_scope_none(self):
         self.prepare_data()
@@ -156,7 +156,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_scope")
+        assert resp["error"] == "invalid_scope"
 
     def test_invalid_user(self):
         self.prepare_data()
@@ -172,7 +172,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
     def test_invalid_grant_type(self):
         self.prepare_data(grant_type="invalid")
@@ -188,7 +188,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unauthorized_client")
+        assert resp["error"] == "unauthorized_client"
 
     def test_authorize_token_no_scope(self):
         self.prepare_data()
@@ -203,7 +203,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_authorize_token_scope(self):
         self.prepare_data()
@@ -219,7 +219,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
     def test_revoke_old_credential(self):
         self.prepare_data()
@@ -235,7 +235,7 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
+        assert "access_token" in resp
 
         rv = self.client.post(
             "/oauth/token",
@@ -246,9 +246,9 @@ class RefreshTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 400)
+        assert rv.status_code == 400
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_grant")
+        assert resp["error"] == "invalid_grant"
 
     def test_token_generator(self):
         m = "tests.flask.test_oauth2.oauth2_server:token_generator"
@@ -266,5 +266,5 @@ class RefreshTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertIn("access_token", resp)
-        self.assertIn("r-refresh_token.1.", resp["access_token"])
+        assert "access_token" in resp
+        assert "r-refresh_token.1." in resp["access_token"]

--- a/tests/flask/test_oauth2/test_revocation_endpoint.py
+++ b/tests/flask/test_oauth2/test_revocation_endpoint.py
@@ -56,29 +56,29 @@ class RevokeTokenTest(TestCase):
         self.prepare_data()
         rv = self.client.post("/oauth/revoke")
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = {"Authorization": "invalid token_string"}
         rv = self.client.post("/oauth/revoke", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("invalid-client", "revoke-secret")
         rv = self.client.post("/oauth/revoke", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
         headers = self.create_basic_header("revoke-client", "invalid-secret")
         rv = self.client.post("/oauth/revoke", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_client")
+        assert resp["error"] == "invalid_client"
 
     def test_invalid_token(self):
         self.prepare_data()
         headers = self.create_basic_header("revoke-client", "revoke-secret")
         rv = self.client.post("/oauth/revoke", headers=headers)
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_request")
+        assert resp["error"] == "invalid_request"
 
         rv = self.client.post(
             "/oauth/revoke",
@@ -87,7 +87,7 @@ class RevokeTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
 
         rv = self.client.post(
             "/oauth/revoke",
@@ -98,7 +98,7 @@ class RevokeTokenTest(TestCase):
             headers=headers,
         )
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "unsupported_token_type")
+        assert resp["error"] == "unsupported_token_type"
 
         rv = self.client.post(
             "/oauth/revoke",
@@ -108,7 +108,7 @@ class RevokeTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
 
     def test_revoke_token_with_hint(self):
         self.prepare_data()
@@ -122,7 +122,7 @@ class RevokeTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
 
     def test_revoke_token_without_hint(self):
         self.prepare_data()
@@ -135,7 +135,7 @@ class RevokeTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 200)
+        assert rv.status_code == 200
 
     def test_revoke_token_bound_to_client(self):
         self.prepare_data()
@@ -163,6 +163,6 @@ class RevokeTokenTest(TestCase):
             },
             headers=headers,
         )
-        self.assertEqual(rv.status_code, 400)
+        assert rv.status_code == 400
         resp = json.loads(rv.data)
-        self.assertEqual(resp["error"], "invalid_grant")
+        assert resp["error"] == "invalid_grant"

--- a/tests/jose/test_chacha20.py
+++ b/tests/jose/test_chacha20.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 from authlib.jose import JsonWebEncryption
 from authlib.jose import OctKey
 from authlib.jose.drafts import register_jwe_draft
@@ -14,12 +16,14 @@ class ChaCha20Test(unittest.TestCase):
         protected = {"alg": "dir", "enc": "C20P"}
         data = jwe.serialize_compact(protected, b"hello", key)
         rv = jwe.deserialize_compact(data, key)
-        self.assertEqual(rv["payload"], b"hello")
+        assert rv["payload"] == b"hello"
 
         key2 = OctKey.generate_key(128, is_private=True)
-        self.assertRaises(ValueError, jwe.deserialize_compact, data, key2)
+        with pytest.raises(ValueError):
+            jwe.deserialize_compact(data, key2)
 
-        self.assertRaises(ValueError, jwe.serialize_compact, protected, b"hello", key2)
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(protected, b"hello", key2)
 
     def test_dir_alg_xc20p(self):
         jwe = JsonWebEncryption()
@@ -27,12 +31,14 @@ class ChaCha20Test(unittest.TestCase):
         protected = {"alg": "dir", "enc": "XC20P"}
         data = jwe.serialize_compact(protected, b"hello", key)
         rv = jwe.deserialize_compact(data, key)
-        self.assertEqual(rv["payload"], b"hello")
+        assert rv["payload"] == b"hello"
 
         key2 = OctKey.generate_key(128, is_private=True)
-        self.assertRaises(ValueError, jwe.deserialize_compact, data, key2)
+        with pytest.raises(ValueError):
+            jwe.deserialize_compact(data, key2)
 
-        self.assertRaises(ValueError, jwe.serialize_compact, protected, b"hello", key2)
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(protected, b"hello", key2)
 
     def test_xc20p_content_encryption_decryption(self):
         # https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-xchacha-03#appendix-A.3.1
@@ -51,16 +57,13 @@ class ChaCha20Test(unittest.TestCase):
         iv = bytes.fromhex("404142434445464748494a4b4c4d4e4f5051525354555657")
 
         ciphertext, tag = enc.encrypt(plaintext, aad, iv, key)
-        self.assertEqual(
-            ciphertext,
-            bytes.fromhex(
-                "bd6d179d3e83d43b9576579493c0e939572a1700252bfaccbed2902c21396cbb"
-                + "731c7f1b0b4aa6440bf3a82f4eda7e39ae64c6708c54c216cb96b72e1213b452"
-                + "2f8c9ba40db5d945b11b69b982c1bb9e3f3fac2bc369488f76b2383565d3fff9"
-                + "21f9664c97637da9768812f615c68b13b52e"
-            ),
+        assert ciphertext == bytes.fromhex(
+            "bd6d179d3e83d43b9576579493c0e939572a1700252bfaccbed2902c21396cbb"
+            + "731c7f1b0b4aa6440bf3a82f4eda7e39ae64c6708c54c216cb96b72e1213b452"
+            + "2f8c9ba40db5d945b11b69b982c1bb9e3f3fac2bc369488f76b2383565d3fff9"
+            + "21f9664c97637da9768812f615c68b13b52e"
         )
-        self.assertEqual(tag, bytes.fromhex("c0875924c1c7987947deafd8780acf49"))
+        assert tag == bytes.fromhex("c0875924c1c7987947deafd8780acf49")
 
         decrypted_plaintext = enc.decrypt(ciphertext, aad, iv, tag, key)
-        self.assertEqual(decrypted_plaintext, plaintext)
+        assert decrypted_plaintext == plaintext

--- a/tests/jose/test_ecdh_1pu.py
+++ b/tests/jose/test_ecdh_1pu.py
@@ -1,6 +1,7 @@
 import unittest
 from collections import OrderedDict
 
+import pytest
 from cryptography.hazmat.primitives.keywrap import InvalidUnwrap
 
 from authlib.common.encoding import json_b64encode
@@ -74,48 +75,48 @@ class ECDH1PUTest(unittest.TestCase):
         _shared_key_e_at_alice = alice_ephemeral_key.exchange_shared_key(
             bob_static_pubkey
         )
-        self.assertEqual(
-            _shared_key_e_at_alice,
-            b"\x9e\x56\xd9\x1d\x81\x71\x35\xd3\x72\x83\x42\x83\xbf\x84\x26\x9c"
-            + b"\xfb\x31\x6e\xa3\xda\x80\x6a\x48\xf6\xda\xa7\x79\x8c\xfe\x90\xc4",
+        assert (
+            _shared_key_e_at_alice
+            == b"\x9e\x56\xd9\x1d\x81\x71\x35\xd3\x72\x83\x42\x83\xbf\x84\x26\x9c"
+            + b"\xfb\x31\x6e\xa3\xda\x80\x6a\x48\xf6\xda\xa7\x79\x8c\xfe\x90\xc4"
         )
 
         _shared_key_s_at_alice = alice_static_key.exchange_shared_key(bob_static_pubkey)
-        self.assertEqual(
-            _shared_key_s_at_alice,
-            b"\xe3\xca\x34\x74\x38\x4c\x9f\x62\xb3\x0b\xfd\x4c\x68\x8b\x3e\x7d"
-            + b"\x41\x10\xa1\xb4\xba\xdc\x3c\xc5\x4e\xf7\xb8\x12\x41\xef\xd5\x0d",
+        assert (
+            _shared_key_s_at_alice
+            == b"\xe3\xca\x34\x74\x38\x4c\x9f\x62\xb3\x0b\xfd\x4c\x68\x8b\x3e\x7d"
+            + b"\x41\x10\xa1\xb4\xba\xdc\x3c\xc5\x4e\xf7\xb8\x12\x41\xef\xd5\x0d"
         )
 
         _shared_key_at_alice = alg.compute_shared_key(
             _shared_key_e_at_alice, _shared_key_s_at_alice
         )
-        self.assertEqual(
-            _shared_key_at_alice,
-            b"\x9e\x56\xd9\x1d\x81\x71\x35\xd3\x72\x83\x42\x83\xbf\x84\x26\x9c"
+        assert (
+            _shared_key_at_alice
+            == b"\x9e\x56\xd9\x1d\x81\x71\x35\xd3\x72\x83\x42\x83\xbf\x84\x26\x9c"
             + b"\xfb\x31\x6e\xa3\xda\x80\x6a\x48\xf6\xda\xa7\x79\x8c\xfe\x90\xc4"
             + b"\xe3\xca\x34\x74\x38\x4c\x9f\x62\xb3\x0b\xfd\x4c\x68\x8b\x3e\x7d"
-            + b"\x41\x10\xa1\xb4\xba\xdc\x3c\xc5\x4e\xf7\xb8\x12\x41\xef\xd5\x0d",
+            + b"\x41\x10\xa1\xb4\xba\xdc\x3c\xc5\x4e\xf7\xb8\x12\x41\xef\xd5\x0d"
         )
 
         _fixed_info_at_alice = alg.compute_fixed_info(headers, enc.key_size, None)
-        self.assertEqual(
-            _fixed_info_at_alice,
-            b"\x00\x00\x00\x07\x41\x32\x35\x36\x47\x43\x4d\x00\x00\x00\x05\x41"
-            + b"\x6c\x69\x63\x65\x00\x00\x00\x03\x42\x6f\x62\x00\x00\x01\x00",
+        assert (
+            _fixed_info_at_alice
+            == b"\x00\x00\x00\x07\x41\x32\x35\x36\x47\x43\x4d\x00\x00\x00\x05\x41"
+            + b"\x6c\x69\x63\x65\x00\x00\x00\x03\x42\x6f\x62\x00\x00\x01\x00"
         )
 
         _dk_at_alice = alg.compute_derived_key(
             _shared_key_at_alice, _fixed_info_at_alice, enc.key_size
         )
-        self.assertEqual(
-            _dk_at_alice,
-            b"\x6c\xaf\x13\x72\x3d\x14\x85\x0a\xd4\xb4\x2c\xd6\xdd\xe9\x35\xbf"
-            + b"\xfd\x2f\xff\x00\xa9\xba\x70\xde\x05\xc2\x03\xa5\xe1\x72\x2c\xa7",
+        assert (
+            _dk_at_alice
+            == b"\x6c\xaf\x13\x72\x3d\x14\x85\x0a\xd4\xb4\x2c\xd6\xdd\xe9\x35\xbf"
+            + b"\xfd\x2f\xff\x00\xa9\xba\x70\xde\x05\xc2\x03\xa5\xe1\x72\x2c\xa7"
         )
-        self.assertEqual(
-            urlsafe_b64encode(_dk_at_alice),
-            b"bK8Tcj0UhQrUtCzW3ek1v_0v_wCpunDeBcIDpeFyLKc",
+        assert (
+            urlsafe_b64encode(_dk_at_alice)
+            == b"bK8Tcj0UhQrUtCzW3ek1v_0v_wCpunDeBcIDpeFyLKc"
         )
 
         # All-in-one method verification
@@ -127,9 +128,9 @@ class ECDH1PUTest(unittest.TestCase):
             enc.key_size,
             None,
         )
-        self.assertEqual(
-            urlsafe_b64encode(dk_at_alice),
-            b"bK8Tcj0UhQrUtCzW3ek1v_0v_wCpunDeBcIDpeFyLKc",
+        assert (
+            urlsafe_b64encode(dk_at_alice)
+            == b"bK8Tcj0UhQrUtCzW3ek1v_0v_wCpunDeBcIDpeFyLKc"
         )
 
         # Derived key computation at Bob
@@ -138,23 +139,23 @@ class ECDH1PUTest(unittest.TestCase):
         _shared_key_e_at_bob = bob_static_key.exchange_shared_key(
             alice_ephemeral_pubkey
         )
-        self.assertEqual(_shared_key_e_at_bob, _shared_key_e_at_alice)
+        assert _shared_key_e_at_bob == _shared_key_e_at_alice
 
         _shared_key_s_at_bob = bob_static_key.exchange_shared_key(alice_static_pubkey)
-        self.assertEqual(_shared_key_s_at_bob, _shared_key_s_at_alice)
+        assert _shared_key_s_at_bob == _shared_key_s_at_alice
 
         _shared_key_at_bob = alg.compute_shared_key(
             _shared_key_e_at_bob, _shared_key_s_at_bob
         )
-        self.assertEqual(_shared_key_at_bob, _shared_key_at_alice)
+        assert _shared_key_at_bob == _shared_key_at_alice
 
         _fixed_info_at_bob = alg.compute_fixed_info(headers, enc.key_size, None)
-        self.assertEqual(_fixed_info_at_bob, _fixed_info_at_alice)
+        assert _fixed_info_at_bob == _fixed_info_at_alice
 
         _dk_at_bob = alg.compute_derived_key(
             _shared_key_at_bob, _fixed_info_at_bob, enc.key_size
         )
-        self.assertEqual(_dk_at_bob, _dk_at_alice)
+        assert _dk_at_bob == _dk_at_alice
 
         # All-in-one method verification
         dk_at_bob = alg.deliver_at_recipient(
@@ -165,7 +166,7 @@ class ECDH1PUTest(unittest.TestCase):
             enc.key_size,
             None,
         )
-        self.assertEqual(dk_at_bob, dk_at_alice)
+        assert dk_at_bob == dk_at_alice
 
     def test_ecdh_1pu_key_agreement_computation_appx_b(self):
         # https://datatracker.ietf.org/doc/html/draft-madden-jose-ecdh-1pu-04#appendix-B
@@ -238,13 +239,11 @@ class ECDH1PUTest(unittest.TestCase):
         aad = to_bytes(protected_segment, "ascii")
 
         ciphertext, tag = enc.encrypt(payload, aad, iv, cek)
-        self.assertEqual(
-            urlsafe_b64encode(ciphertext),
-            b"Az2IWsISEMDJvyc5XRL-3-d-RgNBOGolCsxFFoUXFYw",
+        assert (
+            urlsafe_b64encode(ciphertext)
+            == b"Az2IWsISEMDJvyc5XRL-3-d-RgNBOGolCsxFFoUXFYw"
         )
-        self.assertEqual(
-            urlsafe_b64encode(tag), b"HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"
-        )
+        assert urlsafe_b64encode(tag) == b"HLb4fTlm8spGmij3RyOs2gJ4DpHM4hhVRwdF_hGb3WQ"
 
         # Derived key computation at Alice for Bob
 
@@ -252,51 +251,51 @@ class ECDH1PUTest(unittest.TestCase):
         _shared_key_e_at_alice_for_bob = alice_ephemeral_key.exchange_shared_key(
             bob_static_pubkey
         )
-        self.assertEqual(
-            _shared_key_e_at_alice_for_bob,
-            b"\x32\x81\x08\x96\xe0\xfe\x4d\x57\x0e\xd1\xac\xfc\xed\xf6\x71\x17"
-            + b"\xdc\x19\x4e\xd5\xda\xac\x21\xd8\xff\x7a\xf3\x24\x46\x94\x89\x7f",
+        assert (
+            _shared_key_e_at_alice_for_bob
+            == b"\x32\x81\x08\x96\xe0\xfe\x4d\x57\x0e\xd1\xac\xfc\xed\xf6\x71\x17"
+            + b"\xdc\x19\x4e\xd5\xda\xac\x21\xd8\xff\x7a\xf3\x24\x46\x94\x89\x7f"
         )
 
         _shared_key_s_at_alice_for_bob = alice_static_key.exchange_shared_key(
             bob_static_pubkey
         )
-        self.assertEqual(
-            _shared_key_s_at_alice_for_bob,
-            b"\x21\x57\x61\x2c\x90\x48\xed\xfa\xe7\x7c\xb2\xe4\x23\x71\x40\x60"
-            + b"\x59\x67\xc0\x5c\x7f\x77\xa4\x8e\xea\xf2\xcf\x29\xa5\x73\x7c\x4a",
+        assert (
+            _shared_key_s_at_alice_for_bob
+            == b"\x21\x57\x61\x2c\x90\x48\xed\xfa\xe7\x7c\xb2\xe4\x23\x71\x40\x60"
+            + b"\x59\x67\xc0\x5c\x7f\x77\xa4\x8e\xea\xf2\xcf\x29\xa5\x73\x7c\x4a"
         )
 
         _shared_key_at_alice_for_bob = alg.compute_shared_key(
             _shared_key_e_at_alice_for_bob, _shared_key_s_at_alice_for_bob
         )
-        self.assertEqual(
-            _shared_key_at_alice_for_bob,
-            b"\x32\x81\x08\x96\xe0\xfe\x4d\x57\x0e\xd1\xac\xfc\xed\xf6\x71\x17"
+        assert (
+            _shared_key_at_alice_for_bob
+            == b"\x32\x81\x08\x96\xe0\xfe\x4d\x57\x0e\xd1\xac\xfc\xed\xf6\x71\x17"
             + b"\xdc\x19\x4e\xd5\xda\xac\x21\xd8\xff\x7a\xf3\x24\x46\x94\x89\x7f"
             + b"\x21\x57\x61\x2c\x90\x48\xed\xfa\xe7\x7c\xb2\xe4\x23\x71\x40\x60"
-            + b"\x59\x67\xc0\x5c\x7f\x77\xa4\x8e\xea\xf2\xcf\x29\xa5\x73\x7c\x4a",
+            + b"\x59\x67\xc0\x5c\x7f\x77\xa4\x8e\xea\xf2\xcf\x29\xa5\x73\x7c\x4a"
         )
 
         _fixed_info_at_alice_for_bob = alg.compute_fixed_info(
             protected, alg.key_size, tag
         )
-        self.assertEqual(
-            _fixed_info_at_alice_for_bob,
-            b"\x00\x00\x00\x0f\x45\x43\x44\x48\x2d\x31\x50\x55\x2b\x41\x31\x32"
+        assert (
+            _fixed_info_at_alice_for_bob
+            == b"\x00\x00\x00\x0f\x45\x43\x44\x48\x2d\x31\x50\x55\x2b\x41\x31\x32"
             + b"\x38\x4b\x57\x00\x00\x00\x05\x41\x6c\x69\x63\x65\x00\x00\x00\x0f"
             + b"\x42\x6f\x62\x20\x61\x6e\x64\x20\x43\x68\x61\x72\x6c\x69\x65\x00"
             + b"\x00\x00\x80\x00\x00\x00\x20\x1c\xb6\xf8\x7d\x39\x66\xf2\xca\x46"
             + b"\x9a\x28\xf7\x47\x23\xac\xda\x02\x78\x0e\x91\xcc\xe2\x18\x55\x47"
-            + b"\x07\x45\xfe\x11\x9b\xdd\x64",
+            + b"\x07\x45\xfe\x11\x9b\xdd\x64"
         )
 
         _dk_at_alice_for_bob = alg.compute_derived_key(
             _shared_key_at_alice_for_bob, _fixed_info_at_alice_for_bob, alg.key_size
         )
-        self.assertEqual(
-            _dk_at_alice_for_bob,
-            b"\xdf\x4c\x37\xa0\x66\x83\x06\xa1\x1e\x3d\x6b\x00\x74\xb5\xd8\xdf",
+        assert (
+            _dk_at_alice_for_bob
+            == b"\xdf\x4c\x37\xa0\x66\x83\x06\xa1\x1e\x3d\x6b\x00\x74\xb5\xd8\xdf"
         )
 
         # All-in-one method verification
@@ -308,17 +307,17 @@ class ECDH1PUTest(unittest.TestCase):
             alg.key_size,
             tag,
         )
-        self.assertEqual(
-            dk_at_alice_for_bob,
-            b"\xdf\x4c\x37\xa0\x66\x83\x06\xa1\x1e\x3d\x6b\x00\x74\xb5\xd8\xdf",
+        assert (
+            dk_at_alice_for_bob
+            == b"\xdf\x4c\x37\xa0\x66\x83\x06\xa1\x1e\x3d\x6b\x00\x74\xb5\xd8\xdf"
         )
 
         kek_at_alice_for_bob = alg.aeskw.prepare_key(dk_at_alice_for_bob)
         wrapped_for_bob = alg.aeskw.wrap_cek(cek, kek_at_alice_for_bob)
         ek_for_bob = wrapped_for_bob["ek"]
-        self.assertEqual(
-            urlsafe_b64encode(ek_for_bob),
-            b"pOMVA9_PtoRe7xXW1139NzzN1UhiFoio8lGto9cf0t8PyU-sjNXH8-LIRLycq8CHJQbDwvQeU1cSl55cQ0hGezJu2N9IY0QN",
+        assert (
+            urlsafe_b64encode(ek_for_bob)
+            == b"pOMVA9_PtoRe7xXW1139NzzN1UhiFoio8lGto9cf0t8PyU-sjNXH8-LIRLycq8CHJQbDwvQeU1cSl55cQ0hGezJu2N9IY0QN"
         )
 
         # Derived key computation at Alice for Charlie
@@ -327,45 +326,45 @@ class ECDH1PUTest(unittest.TestCase):
         _shared_key_e_at_alice_for_charlie = alice_ephemeral_key.exchange_shared_key(
             charlie_static_pubkey
         )
-        self.assertEqual(
-            _shared_key_e_at_alice_for_charlie,
-            b"\x89\xdc\xfe\x4c\x37\xc1\xdc\x02\x71\xf3\x46\xb5\xb3\xb1\x9c\x3b"
-            + b"\x70\x5c\xa2\xa7\x2f\x9a\x23\x77\x85\xc3\x44\x06\xfc\xb7\x5f\x10",
+        assert (
+            _shared_key_e_at_alice_for_charlie
+            == b"\x89\xdc\xfe\x4c\x37\xc1\xdc\x02\x71\xf3\x46\xb5\xb3\xb1\x9c\x3b"
+            + b"\x70\x5c\xa2\xa7\x2f\x9a\x23\x77\x85\xc3\x44\x06\xfc\xb7\x5f\x10"
         )
 
         _shared_key_s_at_alice_for_charlie = alice_static_key.exchange_shared_key(
             charlie_static_pubkey
         )
-        self.assertEqual(
-            _shared_key_s_at_alice_for_charlie,
-            b"\x78\xfe\x63\xfc\x66\x1c\xf8\xd1\x8f\x92\xa8\x42\x2a\x64\x18\xe4"
-            + b"\xed\x5e\x20\xa9\x16\x81\x85\xfd\xee\xdc\xa1\xc3\xd8\xe6\xa6\x1c",
+        assert (
+            _shared_key_s_at_alice_for_charlie
+            == b"\x78\xfe\x63\xfc\x66\x1c\xf8\xd1\x8f\x92\xa8\x42\x2a\x64\x18\xe4"
+            + b"\xed\x5e\x20\xa9\x16\x81\x85\xfd\xee\xdc\xa1\xc3\xd8\xe6\xa6\x1c"
         )
 
         _shared_key_at_alice_for_charlie = alg.compute_shared_key(
             _shared_key_e_at_alice_for_charlie, _shared_key_s_at_alice_for_charlie
         )
-        self.assertEqual(
-            _shared_key_at_alice_for_charlie,
-            b"\x89\xdc\xfe\x4c\x37\xc1\xdc\x02\x71\xf3\x46\xb5\xb3\xb1\x9c\x3b"
+        assert (
+            _shared_key_at_alice_for_charlie
+            == b"\x89\xdc\xfe\x4c\x37\xc1\xdc\x02\x71\xf3\x46\xb5\xb3\xb1\x9c\x3b"
             + b"\x70\x5c\xa2\xa7\x2f\x9a\x23\x77\x85\xc3\x44\x06\xfc\xb7\x5f\x10"
             + b"\x78\xfe\x63\xfc\x66\x1c\xf8\xd1\x8f\x92\xa8\x42\x2a\x64\x18\xe4"
-            + b"\xed\x5e\x20\xa9\x16\x81\x85\xfd\xee\xdc\xa1\xc3\xd8\xe6\xa6\x1c",
+            + b"\xed\x5e\x20\xa9\x16\x81\x85\xfd\xee\xdc\xa1\xc3\xd8\xe6\xa6\x1c"
         )
 
         _fixed_info_at_alice_for_charlie = alg.compute_fixed_info(
             protected, alg.key_size, tag
         )
-        self.assertEqual(_fixed_info_at_alice_for_charlie, _fixed_info_at_alice_for_bob)
+        assert _fixed_info_at_alice_for_charlie == _fixed_info_at_alice_for_bob
 
         _dk_at_alice_for_charlie = alg.compute_derived_key(
             _shared_key_at_alice_for_charlie,
             _fixed_info_at_alice_for_charlie,
             alg.key_size,
         )
-        self.assertEqual(
-            _dk_at_alice_for_charlie,
-            b"\x57\xd8\x12\x6f\x1b\x7e\xc4\xcc\xb0\x58\x4d\xac\x03\xcb\x27\xcc",
+        assert (
+            _dk_at_alice_for_charlie
+            == b"\x57\xd8\x12\x6f\x1b\x7e\xc4\xcc\xb0\x58\x4d\xac\x03\xcb\x27\xcc"
         )
 
         # All-in-one method verification
@@ -377,17 +376,17 @@ class ECDH1PUTest(unittest.TestCase):
             alg.key_size,
             tag,
         )
-        self.assertEqual(
-            dk_at_alice_for_charlie,
-            b"\x57\xd8\x12\x6f\x1b\x7e\xc4\xcc\xb0\x58\x4d\xac\x03\xcb\x27\xcc",
+        assert (
+            dk_at_alice_for_charlie
+            == b"\x57\xd8\x12\x6f\x1b\x7e\xc4\xcc\xb0\x58\x4d\xac\x03\xcb\x27\xcc"
         )
 
         kek_at_alice_for_charlie = alg.aeskw.prepare_key(dk_at_alice_for_charlie)
         wrapped_for_charlie = alg.aeskw.wrap_cek(cek, kek_at_alice_for_charlie)
         ek_for_charlie = wrapped_for_charlie["ek"]
-        self.assertEqual(
-            urlsafe_b64encode(ek_for_charlie),
-            b"56GVudgRLIMEElQ7DpXsijJVRSWUSDNdbWkdV3g0GUNq6hcT_GkxwnxlPIWrTXCqRpVKQC8fe4z3PQ2YH2afvjQ28aiCTWFE",
+        assert (
+            urlsafe_b64encode(ek_for_charlie)
+            == b"56GVudgRLIMEElQ7DpXsijJVRSWUSDNdbWkdV3g0GUNq6hcT_GkxwnxlPIWrTXCqRpVKQC8fe4z3PQ2YH2afvjQ28aiCTWFE"
         )
 
         # Derived key computation at Bob for Alice
@@ -396,27 +395,27 @@ class ECDH1PUTest(unittest.TestCase):
         _shared_key_e_at_bob_for_alice = bob_static_key.exchange_shared_key(
             alice_ephemeral_pubkey
         )
-        self.assertEqual(_shared_key_e_at_bob_for_alice, _shared_key_e_at_alice_for_bob)
+        assert _shared_key_e_at_bob_for_alice == _shared_key_e_at_alice_for_bob
 
         _shared_key_s_at_bob_for_alice = bob_static_key.exchange_shared_key(
             alice_static_pubkey
         )
-        self.assertEqual(_shared_key_s_at_bob_for_alice, _shared_key_s_at_alice_for_bob)
+        assert _shared_key_s_at_bob_for_alice == _shared_key_s_at_alice_for_bob
 
         _shared_key_at_bob_for_alice = alg.compute_shared_key(
             _shared_key_e_at_bob_for_alice, _shared_key_s_at_bob_for_alice
         )
-        self.assertEqual(_shared_key_at_bob_for_alice, _shared_key_at_alice_for_bob)
+        assert _shared_key_at_bob_for_alice == _shared_key_at_alice_for_bob
 
         _fixed_info_at_bob_for_alice = alg.compute_fixed_info(
             protected, alg.key_size, tag
         )
-        self.assertEqual(_fixed_info_at_bob_for_alice, _fixed_info_at_alice_for_bob)
+        assert _fixed_info_at_bob_for_alice == _fixed_info_at_alice_for_bob
 
         _dk_at_bob_for_alice = alg.compute_derived_key(
             _shared_key_at_bob_for_alice, _fixed_info_at_bob_for_alice, alg.key_size
         )
-        self.assertEqual(_dk_at_bob_for_alice, _dk_at_alice_for_bob)
+        assert _dk_at_bob_for_alice == _dk_at_alice_for_bob
 
         # All-in-one method verification
         dk_at_bob_for_alice = alg.deliver_at_recipient(
@@ -427,18 +426,18 @@ class ECDH1PUTest(unittest.TestCase):
             alg.key_size,
             tag,
         )
-        self.assertEqual(dk_at_bob_for_alice, dk_at_alice_for_bob)
+        assert dk_at_bob_for_alice == dk_at_alice_for_bob
 
         kek_at_bob_for_alice = alg.aeskw.prepare_key(dk_at_bob_for_alice)
         cek_unwrapped_by_bob = alg.aeskw.unwrap(
             enc, ek_for_bob, protected, kek_at_bob_for_alice
         )
-        self.assertEqual(cek_unwrapped_by_bob, cek)
+        assert cek_unwrapped_by_bob == cek
 
         payload_decrypted_by_bob = enc.decrypt(
             ciphertext, aad, iv, tag, cek_unwrapped_by_bob
         )
-        self.assertEqual(payload_decrypted_by_bob, payload)
+        assert payload_decrypted_by_bob == payload
 
         # Derived key computation at Charlie for Alice
 
@@ -446,37 +445,29 @@ class ECDH1PUTest(unittest.TestCase):
         _shared_key_e_at_charlie_for_alice = charlie_static_key.exchange_shared_key(
             alice_ephemeral_pubkey
         )
-        self.assertEqual(
-            _shared_key_e_at_charlie_for_alice, _shared_key_e_at_alice_for_charlie
-        )
+        assert _shared_key_e_at_charlie_for_alice == _shared_key_e_at_alice_for_charlie
 
         _shared_key_s_at_charlie_for_alice = charlie_static_key.exchange_shared_key(
             alice_static_pubkey
         )
-        self.assertEqual(
-            _shared_key_s_at_charlie_for_alice, _shared_key_s_at_alice_for_charlie
-        )
+        assert _shared_key_s_at_charlie_for_alice == _shared_key_s_at_alice_for_charlie
 
         _shared_key_at_charlie_for_alice = alg.compute_shared_key(
             _shared_key_e_at_charlie_for_alice, _shared_key_s_at_charlie_for_alice
         )
-        self.assertEqual(
-            _shared_key_at_charlie_for_alice, _shared_key_at_alice_for_charlie
-        )
+        assert _shared_key_at_charlie_for_alice == _shared_key_at_alice_for_charlie
 
         _fixed_info_at_charlie_for_alice = alg.compute_fixed_info(
             protected, alg.key_size, tag
         )
-        self.assertEqual(
-            _fixed_info_at_charlie_for_alice, _fixed_info_at_alice_for_charlie
-        )
+        assert _fixed_info_at_charlie_for_alice == _fixed_info_at_alice_for_charlie
 
         _dk_at_charlie_for_alice = alg.compute_derived_key(
             _shared_key_at_charlie_for_alice,
             _fixed_info_at_charlie_for_alice,
             alg.key_size,
         )
-        self.assertEqual(_dk_at_charlie_for_alice, _dk_at_alice_for_charlie)
+        assert _dk_at_charlie_for_alice == _dk_at_alice_for_charlie
 
         # All-in-one method verification
         dk_at_charlie_for_alice = alg.deliver_at_recipient(
@@ -487,18 +478,18 @@ class ECDH1PUTest(unittest.TestCase):
             alg.key_size,
             tag,
         )
-        self.assertEqual(dk_at_charlie_for_alice, dk_at_alice_for_charlie)
+        assert dk_at_charlie_for_alice == dk_at_alice_for_charlie
 
         kek_at_charlie_for_alice = alg.aeskw.prepare_key(dk_at_charlie_for_alice)
         cek_unwrapped_by_charlie = alg.aeskw.unwrap(
             enc, ek_for_charlie, protected, kek_at_charlie_for_alice
         )
-        self.assertEqual(cek_unwrapped_by_charlie, cek)
+        assert cek_unwrapped_by_charlie == cek
 
         payload_decrypted_by_charlie = enc.decrypt(
             ciphertext, aad, iv, tag, cek_unwrapped_by_charlie
         )
-        self.assertEqual(payload_decrypted_by_charlie, payload)
+        assert payload_decrypted_by_charlie == payload
 
     def test_ecdh_1pu_jwe_in_direct_key_agreement_mode(self):
         jwe = JsonWebEncryption()
@@ -530,7 +521,7 @@ class ECDH1PUTest(unittest.TestCase):
                 protected, b"hello", bob_key, sender_key=alice_key
             )
             rv = jwe.deserialize_compact(data, bob_key, sender_key=alice_key)
-            self.assertEqual(rv["payload"], b"hello")
+            assert rv["payload"] == b"hello"
 
     def test_ecdh_1pu_jwe_json_serialization_single_recipient_in_direct_key_agreement_mode(
         self,
@@ -543,7 +534,7 @@ class ECDH1PUTest(unittest.TestCase):
         header_obj = {"protected": protected}
         data = jwe.serialize_json(header_obj, b"hello", bob_key, sender_key=alice_key)
         rv = jwe.deserialize_json(data, bob_key, sender_key=alice_key)
-        self.assertEqual(rv["payload"], b"hello")
+        assert rv["payload"] == b"hello"
 
     def test_ecdh_1pu_jwe_in_key_agreement_with_key_wrapping_mode(self):
         jwe = JsonWebEncryption()
@@ -577,7 +568,7 @@ class ECDH1PUTest(unittest.TestCase):
                     protected, b"hello", bob_key, sender_key=alice_key
                 )
                 rv = jwe.deserialize_compact(data, bob_key, sender_key=alice_key)
-                self.assertEqual(rv["payload"], b"hello")
+                assert rv["payload"] == b"hello"
 
     def test_ecdh_1pu_jwe_with_compact_serialization_ignores_kid_provided_separately_on_decryption(
         self,
@@ -618,7 +609,7 @@ class ECDH1PUTest(unittest.TestCase):
                 rv = jwe.deserialize_compact(
                     data, (bob_kid, bob_key), sender_key=alice_key
                 )
-                self.assertEqual(rv["payload"], b"hello")
+                assert rv["payload"] == b"hello"
 
     def test_ecdh_1pu_jwe_with_okp_keys_in_direct_key_agreement_mode(self):
         jwe = JsonWebEncryption()
@@ -638,7 +629,7 @@ class ECDH1PUTest(unittest.TestCase):
                 protected, b"hello", bob_key, sender_key=alice_key
             )
             rv = jwe.deserialize_compact(data, bob_key, sender_key=alice_key)
-            self.assertEqual(rv["payload"], b"hello")
+            assert rv["payload"] == b"hello"
 
     def test_ecdh_1pu_jwe_with_okp_keys_in_key_agreement_with_key_wrapping_mode(self):
         jwe = JsonWebEncryption()
@@ -660,7 +651,7 @@ class ECDH1PUTest(unittest.TestCase):
                     protected, b"hello", bob_key, sender_key=alice_key
                 )
                 rv = jwe.deserialize_compact(data, bob_key, sender_key=alice_key)
-                self.assertEqual(rv["payload"], b"hello")
+                assert rv["payload"] == b"hello"
 
     def test_ecdh_1pu_encryption_with_json_serialization(self):
         jwe = JsonWebEncryption()
@@ -719,36 +710,32 @@ class ECDH1PUTest(unittest.TestCase):
             header_obj, payload, [bob_key, charlie_key], sender_key=alice_key
         )
 
-        self.assertEqual(
-            data.keys(),
-            {
-                "protected",
-                "unprotected",
-                "recipients",
-                "aad",
-                "iv",
-                "ciphertext",
-                "tag",
-            },
-        )
+        assert data.keys() == {
+            "protected",
+            "unprotected",
+            "recipients",
+            "aad",
+            "iv",
+            "ciphertext",
+            "tag",
+        }
 
         decoded_protected = json_loads(
             urlsafe_b64decode(to_bytes(data["protected"])).decode("utf-8")
         )
-        self.assertEqual(decoded_protected.keys(), protected.keys() | {"epk"})
-        self.assertEqual(
-            {k: decoded_protected[k] for k in decoded_protected.keys() - {"epk"}},
-            protected,
-        )
+        assert decoded_protected.keys() == protected.keys() | {"epk"}
+        assert {
+            k: decoded_protected[k] for k in decoded_protected.keys() - {"epk"}
+        } == protected
 
-        self.assertEqual(data["unprotected"], unprotected)
+        assert data["unprotected"] == unprotected
 
-        self.assertEqual(len(data["recipients"]), len(recipients))
+        assert len(data["recipients"]) == len(recipients)
         for i in range(len(data["recipients"])):
-            self.assertEqual(data["recipients"][i].keys(), {"header", "encrypted_key"})
-            self.assertEqual(data["recipients"][i]["header"], recipients[i]["header"])
+            assert data["recipients"][i].keys() == {"header", "encrypted_key"}
+            assert data["recipients"][i]["header"] == recipients[i]["header"]
 
-        self.assertEqual(urlsafe_b64decode(to_bytes(data["aad"])), jwe_aad)
+        assert urlsafe_b64decode(to_bytes(data["aad"])) == jwe_aad
 
         iv = urlsafe_b64decode(to_bytes(data["iv"]))
         ciphertext = urlsafe_b64decode(to_bytes(data["ciphertext"]))
@@ -769,7 +756,7 @@ class ECDH1PUTest(unittest.TestCase):
         )
         payload_at_bob = enc.decrypt(ciphertext, aad, iv, tag, cek_at_bob)
 
-        self.assertEqual(payload_at_bob, payload)
+        assert payload_at_bob == payload
 
         ek_for_charlie = urlsafe_b64decode(
             to_bytes(data["recipients"][1]["encrypted_key"])
@@ -787,8 +774,8 @@ class ECDH1PUTest(unittest.TestCase):
         )
         payload_at_charlie = enc.decrypt(ciphertext, aad, iv, tag, cek_at_charlie)
 
-        self.assertEqual(cek_at_charlie, cek_at_bob)
-        self.assertEqual(payload_at_charlie, payload)
+        assert cek_at_charlie == cek_at_bob
+        assert payload_at_charlie == payload
 
     def test_ecdh_1pu_decryption_with_json_serialization(self):
         jwe = JsonWebEncryption()
@@ -843,73 +830,65 @@ class ECDH1PUTest(unittest.TestCase):
 
         rv_at_bob = jwe.deserialize_json(data, bob_key, sender_key=alice_key)
 
-        self.assertEqual(rv_at_bob.keys(), {"header", "payload"})
+        assert rv_at_bob.keys() == {"header", "payload"}
 
-        self.assertEqual(
-            rv_at_bob["header"].keys(), {"protected", "unprotected", "recipients"}
-        )
+        assert rv_at_bob["header"].keys() == {"protected", "unprotected", "recipients"}
 
-        self.assertEqual(
-            rv_at_bob["header"]["protected"],
-            {
-                "alg": "ECDH-1PU+A128KW",
-                "enc": "A256CBC-HS512",
-                "apu": "QWxpY2U",
-                "apv": "Qm9iIGFuZCBDaGFybGll",
-                "epk": {
-                    "kty": "OKP",
-                    "crv": "X25519",
-                    "x": "k9of_cpAajy0poW5gaixXGs9nHkwg1AFqUAFa39dyBc",
-                },
+        assert rv_at_bob["header"]["protected"] == {
+            "alg": "ECDH-1PU+A128KW",
+            "enc": "A256CBC-HS512",
+            "apu": "QWxpY2U",
+            "apv": "Qm9iIGFuZCBDaGFybGll",
+            "epk": {
+                "kty": "OKP",
+                "crv": "X25519",
+                "x": "k9of_cpAajy0poW5gaixXGs9nHkwg1AFqUAFa39dyBc",
             },
-        )
+        }
 
-        self.assertEqual(
-            rv_at_bob["header"]["unprotected"],
-            {"jku": "https://alice.example.com/keys.jwks"},
-        )
+        assert rv_at_bob["header"]["unprotected"] == {
+            "jku": "https://alice.example.com/keys.jwks"
+        }
 
-        self.assertEqual(
-            rv_at_bob["header"]["recipients"],
-            [{"header": {"kid": "bob-key-2"}}, {"header": {"kid": "2021-05-06"}}],
-        )
+        assert rv_at_bob["header"]["recipients"] == [
+            {"header": {"kid": "bob-key-2"}},
+            {"header": {"kid": "2021-05-06"}},
+        ]
 
-        self.assertEqual(rv_at_bob["payload"], b"Three is a magic number.")
+        assert rv_at_bob["payload"] == b"Three is a magic number."
 
         rv_at_charlie = jwe.deserialize_json(data, charlie_key, sender_key=alice_key)
 
-        self.assertEqual(rv_at_charlie.keys(), {"header", "payload"})
+        assert rv_at_charlie.keys() == {"header", "payload"}
 
-        self.assertEqual(
-            rv_at_charlie["header"].keys(), {"protected", "unprotected", "recipients"}
-        )
+        assert rv_at_charlie["header"].keys() == {
+            "protected",
+            "unprotected",
+            "recipients",
+        }
 
-        self.assertEqual(
-            rv_at_charlie["header"]["protected"],
-            {
-                "alg": "ECDH-1PU+A128KW",
-                "enc": "A256CBC-HS512",
-                "apu": "QWxpY2U",
-                "apv": "Qm9iIGFuZCBDaGFybGll",
-                "epk": {
-                    "kty": "OKP",
-                    "crv": "X25519",
-                    "x": "k9of_cpAajy0poW5gaixXGs9nHkwg1AFqUAFa39dyBc",
-                },
+        assert rv_at_charlie["header"]["protected"] == {
+            "alg": "ECDH-1PU+A128KW",
+            "enc": "A256CBC-HS512",
+            "apu": "QWxpY2U",
+            "apv": "Qm9iIGFuZCBDaGFybGll",
+            "epk": {
+                "kty": "OKP",
+                "crv": "X25519",
+                "x": "k9of_cpAajy0poW5gaixXGs9nHkwg1AFqUAFa39dyBc",
             },
-        )
+        }
 
-        self.assertEqual(
-            rv_at_charlie["header"]["unprotected"],
-            {"jku": "https://alice.example.com/keys.jwks"},
-        )
+        assert rv_at_charlie["header"]["unprotected"] == {
+            "jku": "https://alice.example.com/keys.jwks"
+        }
 
-        self.assertEqual(
-            rv_at_charlie["header"]["recipients"],
-            [{"header": {"kid": "bob-key-2"}}, {"header": {"kid": "2021-05-06"}}],
-        )
+        assert rv_at_charlie["header"]["recipients"] == [
+            {"header": {"kid": "bob-key-2"}},
+            {"header": {"kid": "2021-05-06"}},
+        ]
 
-        self.assertEqual(rv_at_charlie["payload"], b"Three is a magic number.")
+        assert rv_at_charlie["payload"] == b"Three is a magic number."
 
     def test_ecdh_1pu_jwe_with_json_serialization_when_kid_is_not_specified(self):
         jwe = JsonWebEncryption()
@@ -970,37 +949,27 @@ class ECDH1PUTest(unittest.TestCase):
 
         rv_at_bob = jwe.deserialize_json(data, bob_key, sender_key=alice_key)
 
-        self.assertEqual(
-            rv_at_bob["header"]["protected"].keys(), protected.keys() | {"epk"}
-        )
-        self.assertEqual(
-            {
-                k: rv_at_bob["header"]["protected"][k]
-                for k in rv_at_bob["header"]["protected"].keys() - {"epk"}
-            },
-            protected,
-        )
-        self.assertEqual(rv_at_bob["header"]["unprotected"], unprotected)
-        self.assertEqual(rv_at_bob["header"]["recipients"], recipients)
-        self.assertEqual(rv_at_bob["header"]["aad"], jwe_aad)
-        self.assertEqual(rv_at_bob["payload"], payload)
+        assert rv_at_bob["header"]["protected"].keys() == protected.keys() | {"epk"}
+        assert {
+            k: rv_at_bob["header"]["protected"][k]
+            for k in rv_at_bob["header"]["protected"].keys() - {"epk"}
+        } == protected
+        assert rv_at_bob["header"]["unprotected"] == unprotected
+        assert rv_at_bob["header"]["recipients"] == recipients
+        assert rv_at_bob["header"]["aad"] == jwe_aad
+        assert rv_at_bob["payload"] == payload
 
         rv_at_charlie = jwe.deserialize_json(data, charlie_key, sender_key=alice_key)
 
-        self.assertEqual(
-            rv_at_charlie["header"]["protected"].keys(), protected.keys() | {"epk"}
-        )
-        self.assertEqual(
-            {
-                k: rv_at_charlie["header"]["protected"][k]
-                for k in rv_at_charlie["header"]["protected"].keys() - {"epk"}
-            },
-            protected,
-        )
-        self.assertEqual(rv_at_charlie["header"]["unprotected"], unprotected)
-        self.assertEqual(rv_at_charlie["header"]["recipients"], recipients)
-        self.assertEqual(rv_at_charlie["header"]["aad"], jwe_aad)
-        self.assertEqual(rv_at_charlie["payload"], payload)
+        assert rv_at_charlie["header"]["protected"].keys() == protected.keys() | {"epk"}
+        assert {
+            k: rv_at_charlie["header"]["protected"][k]
+            for k in rv_at_charlie["header"]["protected"].keys() - {"epk"}
+        } == protected
+        assert rv_at_charlie["header"]["unprotected"] == unprotected
+        assert rv_at_charlie["header"]["recipients"] == recipients
+        assert rv_at_charlie["header"]["aad"] == jwe_aad
+        assert rv_at_charlie["payload"] == payload
 
     def test_ecdh_1pu_jwe_with_json_serialization_when_kid_is_specified(self):
         jwe = JsonWebEncryption()
@@ -1064,37 +1033,27 @@ class ECDH1PUTest(unittest.TestCase):
 
         rv_at_bob = jwe.deserialize_json(data, bob_key, sender_key=alice_key)
 
-        self.assertEqual(
-            rv_at_bob["header"]["protected"].keys(), protected.keys() | {"epk"}
-        )
-        self.assertEqual(
-            {
-                k: rv_at_bob["header"]["protected"][k]
-                for k in rv_at_bob["header"]["protected"].keys() - {"epk"}
-            },
-            protected,
-        )
-        self.assertEqual(rv_at_bob["header"]["unprotected"], unprotected)
-        self.assertEqual(rv_at_bob["header"]["recipients"], recipients)
-        self.assertEqual(rv_at_bob["header"]["aad"], jwe_aad)
-        self.assertEqual(rv_at_bob["payload"], payload)
+        assert rv_at_bob["header"]["protected"].keys() == protected.keys() | {"epk"}
+        assert {
+            k: rv_at_bob["header"]["protected"][k]
+            for k in rv_at_bob["header"]["protected"].keys() - {"epk"}
+        } == protected
+        assert rv_at_bob["header"]["unprotected"] == unprotected
+        assert rv_at_bob["header"]["recipients"] == recipients
+        assert rv_at_bob["header"]["aad"] == jwe_aad
+        assert rv_at_bob["payload"] == payload
 
         rv_at_charlie = jwe.deserialize_json(data, charlie_key, sender_key=alice_key)
 
-        self.assertEqual(
-            rv_at_charlie["header"]["protected"].keys(), protected.keys() | {"epk"}
-        )
-        self.assertEqual(
-            {
-                k: rv_at_charlie["header"]["protected"][k]
-                for k in rv_at_charlie["header"]["protected"].keys() - {"epk"}
-            },
-            protected,
-        )
-        self.assertEqual(rv_at_charlie["header"]["unprotected"], unprotected)
-        self.assertEqual(rv_at_charlie["header"]["recipients"], recipients)
-        self.assertEqual(rv_at_charlie["header"]["aad"], jwe_aad)
-        self.assertEqual(rv_at_charlie["payload"], payload)
+        assert rv_at_charlie["header"]["protected"].keys() == protected.keys() | {"epk"}
+        assert {
+            k: rv_at_charlie["header"]["protected"][k]
+            for k in rv_at_charlie["header"]["protected"].keys() - {"epk"}
+        } == protected
+        assert rv_at_charlie["header"]["unprotected"] == unprotected
+        assert rv_at_charlie["header"]["recipients"] == recipients
+        assert rv_at_charlie["header"]["aad"] == jwe_aad
+        assert rv_at_charlie["payload"] == payload
 
     def test_ecdh_1pu_jwe_with_json_serialization_when_kid_is_provided_separately_on_decryption(
         self,
@@ -1172,39 +1131,29 @@ class ECDH1PUTest(unittest.TestCase):
 
         rv_at_bob = jwe.deserialize_json(data, (bob_kid, bob_key), sender_key=alice_key)
 
-        self.assertEqual(
-            rv_at_bob["header"]["protected"].keys(), protected.keys() | {"epk"}
-        )
-        self.assertEqual(
-            {
-                k: rv_at_bob["header"]["protected"][k]
-                for k in rv_at_bob["header"]["protected"].keys() - {"epk"}
-            },
-            protected,
-        )
-        self.assertEqual(rv_at_bob["header"]["unprotected"], unprotected)
-        self.assertEqual(rv_at_bob["header"]["recipients"], recipients)
-        self.assertEqual(rv_at_bob["header"]["aad"], jwe_aad)
-        self.assertEqual(rv_at_bob["payload"], payload)
+        assert rv_at_bob["header"]["protected"].keys() == protected.keys() | {"epk"}
+        assert {
+            k: rv_at_bob["header"]["protected"][k]
+            for k in rv_at_bob["header"]["protected"].keys() - {"epk"}
+        } == protected
+        assert rv_at_bob["header"]["unprotected"] == unprotected
+        assert rv_at_bob["header"]["recipients"] == recipients
+        assert rv_at_bob["header"]["aad"] == jwe_aad
+        assert rv_at_bob["payload"] == payload
 
         rv_at_charlie = jwe.deserialize_json(
             data, (charlie_kid, charlie_key), sender_key=alice_key
         )
 
-        self.assertEqual(
-            rv_at_charlie["header"]["protected"].keys(), protected.keys() | {"epk"}
-        )
-        self.assertEqual(
-            {
-                k: rv_at_charlie["header"]["protected"][k]
-                for k in rv_at_charlie["header"]["protected"].keys() - {"epk"}
-            },
-            protected,
-        )
-        self.assertEqual(rv_at_charlie["header"]["unprotected"], unprotected)
-        self.assertEqual(rv_at_charlie["header"]["recipients"], recipients)
-        self.assertEqual(rv_at_charlie["header"]["aad"], jwe_aad)
-        self.assertEqual(rv_at_charlie["payload"], payload)
+        assert rv_at_charlie["header"]["protected"].keys() == protected.keys() | {"epk"}
+        assert {
+            k: rv_at_charlie["header"]["protected"][k]
+            for k in rv_at_charlie["header"]["protected"].keys() - {"epk"}
+        } == protected
+        assert rv_at_charlie["header"]["unprotected"] == unprotected
+        assert rv_at_charlie["header"]["recipients"] == recipients
+        assert rv_at_charlie["header"]["aad"] == jwe_aad
+        assert rv_at_charlie["payload"] == payload
 
     def test_ecdh_1pu_jwe_with_json_serialization_for_single_recipient(self):
         jwe = JsonWebEncryption()
@@ -1252,18 +1201,15 @@ class ECDH1PUTest(unittest.TestCase):
 
         rv = jwe.deserialize_json(data, bob_key, sender_key=alice_key)
 
-        self.assertEqual(rv["header"]["protected"].keys(), protected.keys() | {"epk"})
-        self.assertEqual(
-            {
-                k: rv["header"]["protected"][k]
-                for k in rv["header"]["protected"].keys() - {"epk"}
-            },
-            protected,
-        )
-        self.assertEqual(rv["header"]["unprotected"], unprotected)
-        self.assertEqual(rv["header"]["recipients"], recipients)
-        self.assertEqual(rv["header"]["aad"], jwe_aad)
-        self.assertEqual(rv["payload"], payload)
+        assert rv["header"]["protected"].keys() == protected.keys() | {"epk"}
+        assert {
+            k: rv["header"]["protected"][k]
+            for k in rv["header"]["protected"].keys() - {"epk"}
+        } == protected
+        assert rv["header"]["unprotected"] == unprotected
+        assert rv["header"]["recipients"] == recipients
+        assert rv["header"]["aad"] == jwe_aad
+        assert rv["payload"] == payload
 
     def test_ecdh_1pu_encryption_fails_json_serialization_multiple_recipients_in_direct_key_agreement_mode(
         self,
@@ -1275,14 +1221,13 @@ class ECDH1PUTest(unittest.TestCase):
 
         protected = {"alg": "ECDH-1PU", "enc": "A128GCM"}
         header_obj = {"protected": protected}
-        self.assertRaises(
-            InvalidAlgorithmForMultipleRecipientsMode,
-            jwe.serialize_json,
-            header_obj,
-            b"hello",
-            [bob_key, charlie_key],
-            sender_key=alice_key,
-        )
+        with pytest.raises(InvalidAlgorithmForMultipleRecipientsMode):
+            jwe.serialize_json(
+                header_obj,
+                b"hello",
+                [bob_key, charlie_key],
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_fails_if_not_aes_cbc_hmac_sha2_enc_is_used_with_kw(
         self,
@@ -1313,14 +1258,15 @@ class ECDH1PUTest(unittest.TestCase):
                 "A256GCM",
             ]:
                 protected = {"alg": alg, "enc": enc}
-                self.assertRaises(
-                    InvalidEncryptionAlgorithmForECDH1PUWithKeyWrappingError,
-                    jwe.serialize_compact,
-                    protected,
-                    b"hello",
-                    bob_key,
-                    sender_key=alice_key,
-                )
+                with pytest.raises(
+                    InvalidEncryptionAlgorithmForECDH1PUWithKeyWrappingError
+                ):
+                    jwe.serialize_compact(
+                        protected,
+                        b"hello",
+                        bob_key,
+                        sender_key=alice_key,
+                    )
 
     def test_ecdh_1pu_encryption_with_public_sender_key_fails(self):
         jwe = JsonWebEncryption()
@@ -1339,14 +1285,13 @@ class ECDH1PUTest(unittest.TestCase):
             "y": "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck",
             "d": "VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw",
         }
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_decryption_with_public_recipient_key_fails(self):
         jwe = JsonWebEncryption()
@@ -1366,9 +1311,8 @@ class ECDH1PUTest(unittest.TestCase):
             "y": "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck",
         }
         data = jwe.serialize_compact(protected, b"hello", bob_key, sender_key=alice_key)
-        self.assertRaises(
-            ValueError, jwe.deserialize_compact, data, bob_key, sender_key=alice_key
-        )
+        with pytest.raises(ValueError):
+            jwe.deserialize_compact(data, bob_key, sender_key=alice_key)
 
     def test_ecdh_1pu_encryption_fails_if_key_types_are_different(self):
         jwe = JsonWebEncryption()
@@ -1376,25 +1320,23 @@ class ECDH1PUTest(unittest.TestCase):
 
         alice_key = ECKey.generate_key("P-256", is_private=True)
         bob_key = OKPKey.generate_key("X25519", is_private=False)
-        self.assertRaises(
-            Exception,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(TypeError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
         alice_key = OKPKey.generate_key("X25519", is_private=True)
         bob_key = ECKey.generate_key("P-256", is_private=False)
-        self.assertRaises(
-            Exception,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(TypeError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_fails_if_keys_curves_are_different(self):
         jwe = JsonWebEncryption()
@@ -1402,36 +1344,33 @@ class ECDH1PUTest(unittest.TestCase):
 
         alice_key = ECKey.generate_key("P-256", is_private=True)
         bob_key = ECKey.generate_key("secp256k1", is_private=False)
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
         alice_key = ECKey.generate_key("P-384", is_private=True)
         bob_key = ECKey.generate_key("P-521", is_private=False)
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
         alice_key = OKPKey.generate_key("X25519", is_private=True)
         bob_key = OKPKey.generate_key("X448", is_private=False)
-        self.assertRaises(
-            TypeError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(TypeError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_fails_if_key_points_are_not_actually_on_same_curve(
         self,
@@ -1453,14 +1392,13 @@ class ECDH1PUTest(unittest.TestCase):
             "y": "K0srqSkbo1Yeckr0YoQA8r_rOz0ZUStiv3mc1qn46pg",
         }  # the point is not on P-256 curve but is actually on secp256k1 curve
 
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
         alice_key = {
             "kty": "EC",
@@ -1476,14 +1414,13 @@ class ECDH1PUTest(unittest.TestCase):
             "y": "hXo9p1EjW6W4opAQdmfNgyxztkNxYwn9L4FVTLX51KNEsW0aqueLm96adRmf0HoGIbNhIdcIlXOKlRUHqgunDkM",
         }  # the point is indeed on P-521 curve
 
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
         alice_key = OKPKey.import_key(
             {
@@ -1501,14 +1438,13 @@ class ECDH1PUTest(unittest.TestCase):
             }
         )  # the point is not on X25519 curve but is actually on X448 curve
 
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
         alice_key = OKPKey.import_key(
             {
@@ -1526,14 +1462,13 @@ class ECDH1PUTest(unittest.TestCase):
             }
         )  # the point is indeed on X448 curve
 
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_fails_if_keys_curve_is_inappropriate(self):
         jwe = JsonWebEncryption()
@@ -1545,14 +1480,13 @@ class ECDH1PUTest(unittest.TestCase):
         bob_key = OKPKey.generate_key(
             "Ed25519", is_private=False
         )  # use Ed25519 instead of X25519
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_compact,
-            protected,
-            b"hello",
-            bob_key,
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_compact(
+                protected,
+                b"hello",
+                bob_key,
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_for_multiple_recipients_fails_if_key_types_are_different(
         self,
@@ -1565,14 +1499,13 @@ class ECDH1PUTest(unittest.TestCase):
         bob_key = ECKey.generate_key("P-256", is_private=False)
         charlie_key = OKPKey.generate_key("X25519", is_private=False)
 
-        self.assertRaises(
-            Exception,
-            jwe.serialize_json,
-            header_obj,
-            b"hello",
-            [bob_key, charlie_key],
-            sender_key=alice_key,
-        )
+        with pytest.raises(TypeError):
+            jwe.serialize_json(
+                header_obj,
+                b"hello",
+                [bob_key, charlie_key],
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_for_multiple_recipients_fails_if_keys_curves_are_different(
         self,
@@ -1585,14 +1518,13 @@ class ECDH1PUTest(unittest.TestCase):
         bob_key = OKPKey.generate_key("X448", is_private=False)
         charlie_key = OKPKey.generate_key("X25519", is_private=False)
 
-        self.assertRaises(
-            TypeError,
-            jwe.serialize_json,
-            header_obj,
-            b"hello",
-            [bob_key, charlie_key],
-            sender_key=alice_key,
-        )
+        with pytest.raises(TypeError):
+            jwe.serialize_json(
+                header_obj,
+                b"hello",
+                [bob_key, charlie_key],
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_for_multiple_recipients_fails_if_key_points_are_not_actually_on_same_curve(
         self,
@@ -1621,14 +1553,13 @@ class ECDH1PUTest(unittest.TestCase):
             "y": "K0srqSkbo1Yeckr0YoQA8r_rOz0ZUStiv3mc1qn46pg",
         }  # the point is not on P-256 curve but is actually on secp256k1 curve
 
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_json,
-            header_obj,
-            b"hello",
-            [bob_key, charlie_key],
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_json(
+                header_obj,
+                b"hello",
+                [bob_key, charlie_key],
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_encryption_for_multiple_recipients_fails_if_keys_curve_is_inappropriate(
         self,
@@ -1647,14 +1578,13 @@ class ECDH1PUTest(unittest.TestCase):
             "Ed25519", is_private=False
         )  # use Ed25519 instead of X25519
 
-        self.assertRaises(
-            ValueError,
-            jwe.serialize_json,
-            header_obj,
-            b"hello",
-            [bob_key, charlie_key],
-            sender_key=alice_key,
-        )
+        with pytest.raises(ValueError):
+            jwe.serialize_json(
+                header_obj,
+                b"hello",
+                [bob_key, charlie_key],
+                sender_key=alice_key,
+            )
 
     def test_ecdh_1pu_decryption_fails_if_key_matches_to_no_recipient(self):
         jwe = JsonWebEncryption()
@@ -1708,6 +1638,5 @@ class ECDH1PUTest(unittest.TestCase):
 
         data = jwe.serialize_json(header_obj, payload, bob_key, sender_key=alice_key)
 
-        self.assertRaises(
-            InvalidUnwrap, jwe.deserialize_json, data, charlie_key, sender_key=alice_key
-        )
+        with pytest.raises(InvalidUnwrap):
+            jwe.deserialize_json(data, charlie_key, sender_key=alice_key)

--- a/tests/jose/test_jwk.py
+++ b/tests/jose/test_jwk.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 from authlib.common.encoding import base64_to_int
 from authlib.common.encoding import json_dumps
 from authlib.jose import ECKey
@@ -11,12 +13,7 @@ from authlib.jose import RSAKey
 from tests.util import read_file_path
 
 
-class BaseTest(unittest.TestCase):
-    def assertBase64IntEqual(self, x, y):
-        self.assertEqual(base64_to_int(x), base64_to_int(y))
-
-
-class OctKeyTest(BaseTest):
+class OctKeyTest(unittest.TestCase):
     def test_import_oct_key(self):
         # https://tools.ietf.org/html/rfc7520#section-3.5
         obj = {
@@ -28,56 +25,56 @@ class OctKeyTest(BaseTest):
         }
         key = OctKey.import_key(obj)
         new_obj = key.as_dict()
-        self.assertEqual(obj["k"], new_obj["k"])
-        self.assertIn("use", new_obj)
+        assert obj["k"] == new_obj["k"]
+        assert "use" in new_obj
 
     def test_invalid_oct_key(self):
-        self.assertRaises(ValueError, OctKey.import_key, {})
+        with pytest.raises(ValueError):
+            OctKey.import_key({})
 
     def test_generate_oct_key(self):
-        self.assertRaises(ValueError, OctKey.generate_key, 251)
+        with pytest.raises(ValueError):
+            OctKey.generate_key(251)
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError, match="oct key can not be generated as public"):
             OctKey.generate_key(is_private=False)
 
-        self.assertEqual(str(cm.exception), "oct key can not be generated as public")
-
         key = OctKey.generate_key()
-        self.assertIn("kid", key.as_dict())
-        self.assertNotIn("use", key.as_dict())
+        assert "kid" in key.as_dict()
+        assert "use" not in key.as_dict()
 
         key2 = OctKey.import_key(key, {"use": "sig"})
-        self.assertIn("use", key2.as_dict())
+        assert "use" in key2.as_dict()
 
 
-class RSAKeyTest(BaseTest):
+class RSAKeyTest(unittest.TestCase):
     def test_import_ssh_pem(self):
         raw = read_file_path("ssh_public.pem")
         key = RSAKey.import_key(raw)
         obj = key.as_dict()
-        self.assertEqual(obj["kty"], "RSA")
+        assert obj["kty"] == "RSA"
 
     def test_rsa_public_key(self):
         # https://tools.ietf.org/html/rfc7520#section-3.3
         obj = read_file_path("jwk_public.json")
         key = RSAKey.import_key(obj)
         new_obj = key.as_dict()
-        self.assertBase64IntEqual(new_obj["n"], obj["n"])
-        self.assertBase64IntEqual(new_obj["e"], obj["e"])
+        assert base64_to_int(new_obj["n"]) == base64_to_int(obj["n"])
+        assert base64_to_int(new_obj["e"]) == base64_to_int(obj["e"])
 
     def test_rsa_private_key(self):
         # https://tools.ietf.org/html/rfc7520#section-3.4
         obj = read_file_path("jwk_private.json")
         key = RSAKey.import_key(obj)
         new_obj = key.as_dict(is_private=True)
-        self.assertBase64IntEqual(new_obj["n"], obj["n"])
-        self.assertBase64IntEqual(new_obj["e"], obj["e"])
-        self.assertBase64IntEqual(new_obj["d"], obj["d"])
-        self.assertBase64IntEqual(new_obj["p"], obj["p"])
-        self.assertBase64IntEqual(new_obj["q"], obj["q"])
-        self.assertBase64IntEqual(new_obj["dp"], obj["dp"])
-        self.assertBase64IntEqual(new_obj["dq"], obj["dq"])
-        self.assertBase64IntEqual(new_obj["qi"], obj["qi"])
+        assert base64_to_int(new_obj["n"]) == base64_to_int(obj["n"])
+        assert base64_to_int(new_obj["e"]) == base64_to_int(obj["e"])
+        assert base64_to_int(new_obj["d"]) == base64_to_int(obj["d"])
+        assert base64_to_int(new_obj["p"]) == base64_to_int(obj["p"])
+        assert base64_to_int(new_obj["q"]) == base64_to_int(obj["q"])
+        assert base64_to_int(new_obj["dp"]) == base64_to_int(obj["dp"])
+        assert base64_to_int(new_obj["dq"]) == base64_to_int(obj["dq"])
+        assert base64_to_int(new_obj["qi"]) == base64_to_int(obj["qi"])
 
     def test_rsa_private_key2(self):
         rsa_obj = read_file_path("jwk_private.json")
@@ -91,17 +88,18 @@ class RSAKeyTest(BaseTest):
         }
         key = RSAKey.import_key(obj)
         new_obj = key.as_dict(is_private=True)
-        self.assertBase64IntEqual(new_obj["n"], obj["n"])
-        self.assertBase64IntEqual(new_obj["e"], obj["e"])
-        self.assertBase64IntEqual(new_obj["d"], obj["d"])
-        self.assertBase64IntEqual(new_obj["p"], rsa_obj["p"])
-        self.assertBase64IntEqual(new_obj["q"], rsa_obj["q"])
-        self.assertBase64IntEqual(new_obj["dp"], rsa_obj["dp"])
-        self.assertBase64IntEqual(new_obj["dq"], rsa_obj["dq"])
-        self.assertBase64IntEqual(new_obj["qi"], rsa_obj["qi"])
+        assert base64_to_int(new_obj["n"]) == base64_to_int(obj["n"])
+        assert base64_to_int(new_obj["e"]) == base64_to_int(obj["e"])
+        assert base64_to_int(new_obj["d"]) == base64_to_int(obj["d"])
+        assert base64_to_int(new_obj["p"]) == base64_to_int(rsa_obj["p"])
+        assert base64_to_int(new_obj["q"]) == base64_to_int(rsa_obj["q"])
+        assert base64_to_int(new_obj["dp"]) == base64_to_int(rsa_obj["dp"])
+        assert base64_to_int(new_obj["dq"]) == base64_to_int(rsa_obj["dq"])
+        assert base64_to_int(new_obj["qi"]) == base64_to_int(rsa_obj["qi"])
 
     def test_invalid_rsa(self):
-        self.assertRaises(ValueError, RSAKey.import_key, {"kty": "RSA"})
+        with pytest.raises(ValueError):
+            RSAKey.import_key({"kty": "RSA"})
         rsa_obj = read_file_path("jwk_private.json")
         obj = {
             "kty": "RSA",
@@ -112,64 +110,71 @@ class RSAKeyTest(BaseTest):
             "p": rsa_obj["p"],
             "e": "AQAB",
         }
-        self.assertRaises(ValueError, RSAKey.import_key, obj)
+        with pytest.raises(ValueError):
+            RSAKey.import_key(obj)
 
     def test_rsa_key_generate(self):
-        self.assertRaises(ValueError, RSAKey.generate_key, 256)
-        self.assertRaises(ValueError, RSAKey.generate_key, 2001)
+        with pytest.raises(ValueError):
+            RSAKey.generate_key(256)
+        with pytest.raises(ValueError):
+            RSAKey.generate_key(2001)
 
         key1 = RSAKey.generate_key(is_private=True)
-        self.assertIn(b"PRIVATE", key1.as_pem(is_private=True))
-        self.assertIn(b"PUBLIC", key1.as_pem(is_private=False))
+        assert b"PRIVATE" in key1.as_pem(is_private=True)
+        assert b"PUBLIC" in key1.as_pem(is_private=False)
 
         key2 = RSAKey.generate_key(is_private=False)
-        self.assertRaises(ValueError, key2.as_pem, True)
-        self.assertIn(b"PUBLIC", key2.as_pem(is_private=False))
+        with pytest.raises(ValueError):
+            key2.as_pem(True)
+        assert b"PUBLIC" in key2.as_pem(is_private=False)
 
 
-class ECKeyTest(BaseTest):
+class ECKeyTest(unittest.TestCase):
     def test_ec_public_key(self):
         # https://tools.ietf.org/html/rfc7520#section-3.1
         obj = read_file_path("secp521r1-public.json")
         key = ECKey.import_key(obj)
         new_obj = key.as_dict()
-        self.assertEqual(new_obj["crv"], obj["crv"])
-        self.assertBase64IntEqual(new_obj["x"], obj["x"])
-        self.assertBase64IntEqual(new_obj["y"], obj["y"])
-        self.assertEqual(key.as_json()[0], "{")
+        assert new_obj["crv"] == obj["crv"]
+        assert base64_to_int(new_obj["x"]) == base64_to_int(obj["x"])
+        assert base64_to_int(new_obj["y"]) == base64_to_int(obj["y"])
+        assert key.as_json()[0] == "{"
 
     def test_ec_private_key(self):
         # https://tools.ietf.org/html/rfc7520#section-3.2
         obj = read_file_path("secp521r1-private.json")
         key = ECKey.import_key(obj)
         new_obj = key.as_dict(is_private=True)
-        self.assertEqual(new_obj["crv"], obj["crv"])
-        self.assertBase64IntEqual(new_obj["x"], obj["x"])
-        self.assertBase64IntEqual(new_obj["y"], obj["y"])
-        self.assertBase64IntEqual(new_obj["d"], obj["d"])
+        assert new_obj["crv"] == obj["crv"]
+        assert base64_to_int(new_obj["x"]) == base64_to_int(obj["x"])
+        assert base64_to_int(new_obj["y"]) == base64_to_int(obj["y"])
+        assert base64_to_int(new_obj["d"]) == base64_to_int(obj["d"])
 
     def test_invalid_ec(self):
-        self.assertRaises(ValueError, ECKey.import_key, {"kty": "EC"})
+        with pytest.raises(ValueError):
+            ECKey.import_key({"kty": "EC"})
 
     def test_ec_key_generate(self):
-        self.assertRaises(ValueError, ECKey.generate_key, "Invalid")
+        with pytest.raises(ValueError):
+            ECKey.generate_key("Invalid")
 
         key1 = ECKey.generate_key("P-384", is_private=True)
-        self.assertIn(b"PRIVATE", key1.as_pem(is_private=True))
-        self.assertIn(b"PUBLIC", key1.as_pem(is_private=False))
+        assert b"PRIVATE" in key1.as_pem(is_private=True)
+        assert b"PUBLIC" in key1.as_pem(is_private=False)
 
         key2 = ECKey.generate_key("P-256", is_private=False)
-        self.assertRaises(ValueError, key2.as_pem, True)
-        self.assertIn(b"PUBLIC", key2.as_pem(is_private=False))
+        with pytest.raises(ValueError):
+            key2.as_pem(True)
+        assert b"PUBLIC" in key2.as_pem(is_private=False)
 
 
-class OKPKeyTest(BaseTest):
+class OKPKeyTest(unittest.TestCase):
     def test_import_okp_ssh_key(self):
         raw = read_file_path("ed25519-ssh.pub")
         key = OKPKey.import_key(raw)
         obj = key.as_dict()
-        self.assertEqual(obj["kty"], "OKP")
-        self.assertEqual(obj["crv"], "Ed25519")
+        assert obj["kty"] == "OKP"
+        assert obj["crv"] == "Ed25519"
 
     def test_import_okp_public_key(self):
         obj = {
@@ -179,15 +184,15 @@ class OKPKeyTest(BaseTest):
         }
         key = OKPKey.import_key(obj)
         new_obj = key.as_dict()
-        self.assertEqual(obj["x"], new_obj["x"])
+        assert obj["x"] == new_obj["x"]
 
     def test_import_okp_private_pem(self):
         raw = read_file_path("ed25519-pkcs8.pem")
         key = OKPKey.import_key(raw)
         obj = key.as_dict(is_private=True)
-        self.assertEqual(obj["kty"], "OKP")
-        self.assertEqual(obj["crv"], "Ed25519")
-        self.assertIn("d", obj)
+        assert obj["kty"] == "OKP"
+        assert obj["crv"] == "Ed25519"
+        assert "d" in obj
 
     def test_import_okp_private_dict(self):
         obj = {
@@ -198,72 +203,76 @@ class OKPKeyTest(BaseTest):
         }
         key = OKPKey.import_key(obj)
         new_obj = key.as_dict(is_private=True)
-        self.assertEqual(obj["d"], new_obj["d"])
+        assert obj["d"] == new_obj["d"]
 
     def test_okp_key_generate_pem(self):
-        self.assertRaises(ValueError, OKPKey.generate_key, "invalid")
+        with pytest.raises(ValueError):
+            OKPKey.generate_key("invalid")
 
         key1 = OKPKey.generate_key("Ed25519", is_private=True)
-        self.assertIn(b"PRIVATE", key1.as_pem(is_private=True))
-        self.assertIn(b"PUBLIC", key1.as_pem(is_private=False))
+        assert b"PRIVATE" in key1.as_pem(is_private=True)
+        assert b"PUBLIC" in key1.as_pem(is_private=False)
 
         key2 = OKPKey.generate_key("X25519", is_private=False)
-        self.assertRaises(ValueError, key2.as_pem, True)
-        self.assertIn(b"PUBLIC", key2.as_pem(is_private=False))
+        with pytest.raises(ValueError):
+            key2.as_pem(True)
+        assert b"PUBLIC" in key2.as_pem(is_private=False)
 
 
-class JWKTest(BaseTest):
+class JWKTest(unittest.TestCase):
     def test_generate_keys(self):
         key = JsonWebKey.generate_key(kty="oct", crv_or_size=256, is_private=True)
-        self.assertEqual(key["kty"], "oct")
+        assert key["kty"] == "oct"
 
         key = JsonWebKey.generate_key(kty="EC", crv_or_size="P-256")
-        self.assertEqual(key["kty"], "EC")
+        assert key["kty"] == "EC"
 
         key = JsonWebKey.generate_key(kty="RSA", crv_or_size=2048)
-        self.assertEqual(key["kty"], "RSA")
+        assert key["kty"] == "RSA"
 
         key = JsonWebKey.generate_key(kty="OKP", crv_or_size="Ed25519")
-        self.assertEqual(key["kty"], "OKP")
+        assert key["kty"] == "OKP"
 
     def test_import_keys(self):
         rsa_pub_pem = read_file_path("rsa_public.pem")
-        self.assertRaises(ValueError, JsonWebKey.import_key, rsa_pub_pem, {"kty": "EC"})
+        with pytest.raises(ValueError):
+            JsonWebKey.import_key(rsa_pub_pem, {"kty": "EC"})
 
         key = JsonWebKey.import_key(raw=rsa_pub_pem, options={"kty": "RSA"})
-        self.assertIn("e", dict(key))
-        self.assertIn("n", dict(key))
+        assert "e" in dict(key)
+        assert "n" in dict(key)
 
         key = JsonWebKey.import_key(raw=rsa_pub_pem)
-        self.assertIn("e", dict(key))
-        self.assertIn("n", dict(key))
+        assert "e" in dict(key)
+        assert "n" in dict(key)
 
     def test_import_key_set(self):
         jwks_public = read_file_path("jwks_public.json")
         key_set1 = JsonWebKey.import_key_set(jwks_public)
         key1 = key_set1.find_by_kid("abc")
-        self.assertEqual(key1["e"], "AQAB")
+        assert key1["e"] == "AQAB"
 
         key_set2 = JsonWebKey.import_key_set(jwks_public["keys"])
         key2 = key_set2.find_by_kid("abc")
-        self.assertEqual(key2["e"], "AQAB")
+        assert key2["e"] == "AQAB"
 
         key_set3 = JsonWebKey.import_key_set(json_dumps(jwks_public))
         key3 = key_set3.find_by_kid("abc")
-        self.assertEqual(key3["e"], "AQAB")
+        assert key3["e"] == "AQAB"
 
-        self.assertRaises(ValueError, JsonWebKey.import_key_set, "invalid")
+        with pytest.raises(ValueError):
+            JsonWebKey.import_key_set("invalid")
 
     def test_thumbprint(self):
         # https://tools.ietf.org/html/rfc7638#section-3.1
         data = read_file_path("thumbprint_example.json")
         key = JsonWebKey.import_key(data)
         expected = "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"
-        self.assertEqual(key.thumbprint(), expected)
+        assert key.thumbprint() == expected
 
     def test_key_set(self):
         key = RSAKey.generate_key(is_private=True)
         key_set = KeySet([key])
         obj = key_set.as_dict()["keys"][0]
-        self.assertIn("kid", obj)
-        self.assertEqual(key_set.as_json()[0], "{")
+        assert "kid" in obj
+        assert key_set.as_json()[0] == "{"

--- a/tests/jose/test_jws.py
+++ b/tests/jose/test_jws.py
@@ -1,6 +1,8 @@
 import json
 import unittest
 
+import pytest
+
 from authlib.jose import JsonWebSignature
 from authlib.jose import errors
 from tests.util import read_file_path
@@ -9,58 +11,58 @@ from tests.util import read_file_path
 class JWSTest(unittest.TestCase):
     def test_invalid_input(self):
         jws = JsonWebSignature()
-        self.assertRaises(errors.DecodeError, jws.deserialize, "a", "k")
-        self.assertRaises(errors.DecodeError, jws.deserialize, "a.b.c", "k")
-        self.assertRaises(errors.DecodeError, jws.deserialize, "YQ.YQ.YQ", "k")  # a
-        self.assertRaises(errors.DecodeError, jws.deserialize, "W10.a.YQ", "k")  # []
-        self.assertRaises(errors.DecodeError, jws.deserialize, "e30.a.YQ", "k")  # {}
-        self.assertRaises(
-            errors.DecodeError, jws.deserialize, "eyJhbGciOiJzIn0.a.YQ", "k"
-        )
-        self.assertRaises(
-            errors.DecodeError, jws.deserialize, "eyJhbGciOiJzIn0.YQ.a", "k"
-        )
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize("a", "k")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize("a.b.c", "k")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize("YQ.YQ.YQ", "k")  # a
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize("W10.a.YQ", "k")  # []
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize("e30.a.YQ", "k")  # {}
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize("eyJhbGciOiJzIn0.a.YQ", "k")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize("eyJhbGciOiJzIn0.YQ.a", "k")
 
     def test_invalid_alg(self):
         jws = JsonWebSignature()
-        self.assertRaises(
-            errors.UnsupportedAlgorithmError,
-            jws.deserialize,
-            "eyJhbGciOiJzIn0.YQ.YQ",
-            "k",
-        )
-        self.assertRaises(errors.MissingAlgorithmError, jws.serialize, {}, "", "k")
-        self.assertRaises(
-            errors.UnsupportedAlgorithmError, jws.serialize, {"alg": "s"}, "", "k"
-        )
+        with pytest.raises(errors.UnsupportedAlgorithmError):
+            jws.deserialize(
+                "eyJhbGciOiJzIn0.YQ.YQ",
+                "k",
+            )
+        with pytest.raises(errors.MissingAlgorithmError):
+            jws.serialize({}, "", "k")
+        with pytest.raises(errors.UnsupportedAlgorithmError):
+            jws.serialize({"alg": "s"}, "", "k")
 
     def test_bad_signature(self):
         jws = JsonWebSignature()
         s = "eyJhbGciOiJIUzI1NiJ9.YQ.YQ"
-        self.assertRaises(errors.BadSignatureError, jws.deserialize, s, "k")
+        with pytest.raises(errors.BadSignatureError):
+            jws.deserialize(s, "k")
 
     def test_not_supported_alg(self):
         jws = JsonWebSignature(algorithms=["HS256"])
         s = jws.serialize({"alg": "HS256"}, "hello", "secret")
 
         jws = JsonWebSignature(algorithms=["RS256"])
-        self.assertRaises(
-            errors.UnsupportedAlgorithmError,
-            lambda: jws.serialize({"alg": "HS256"}, "hello", "secret"),
-        )
+        with pytest.raises(errors.UnsupportedAlgorithmError):
+            jws.serialize({"alg": "HS256"}, "hello", "secret")
 
-        self.assertRaises(
-            errors.UnsupportedAlgorithmError, jws.deserialize, s, "secret"
-        )
+        with pytest.raises(errors.UnsupportedAlgorithmError):
+            jws.deserialize(s, "secret")
 
     def test_compact_jws(self):
         jws = JsonWebSignature(algorithms=["HS256"])
         s = jws.serialize({"alg": "HS256"}, "hello", "secret")
         data = jws.deserialize(s, "secret")
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "HS256")
-        self.assertNotIn("signature", data)
+        assert payload == b"hello"
+        assert header["alg"] == "HS256"
+        assert "signature" not in data
 
     def test_compact_rsa(self):
         jws = JsonWebSignature()
@@ -69,15 +71,16 @@ class JWSTest(unittest.TestCase):
         s = jws.serialize({"alg": "RS256"}, "hello", private_key)
         data = jws.deserialize(s, public_key)
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "RS256")
+        assert payload == b"hello"
+        assert header["alg"] == "RS256"
 
         # can deserialize with private key
         data2 = jws.deserialize(s, private_key)
-        self.assertEqual(data, data2)
+        assert data == data2
 
         ssh_pub_key = read_file_path("ssh_public.pem")
-        self.assertRaises(errors.BadSignatureError, jws.deserialize, s, ssh_pub_key)
+        with pytest.raises(errors.BadSignatureError):
+            jws.deserialize(s, ssh_pub_key)
 
     def test_compact_rsa_pss(self):
         jws = JsonWebSignature()
@@ -86,48 +89,50 @@ class JWSTest(unittest.TestCase):
         s = jws.serialize({"alg": "PS256"}, "hello", private_key)
         data = jws.deserialize(s, public_key)
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "PS256")
+        assert payload == b"hello"
+        assert header["alg"] == "PS256"
         ssh_pub_key = read_file_path("ssh_public.pem")
-        self.assertRaises(errors.BadSignatureError, jws.deserialize, s, ssh_pub_key)
+        with pytest.raises(errors.BadSignatureError):
+            jws.deserialize(s, ssh_pub_key)
 
     def test_compact_none(self):
         jws = JsonWebSignature(algorithms=["none"])
         s = jws.serialize({"alg": "none"}, "hello", None)
         data = jws.deserialize(s, None)
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "none")
+        assert payload == b"hello"
+        assert header["alg"] == "none"
 
     def test_flattened_json_jws(self):
         jws = JsonWebSignature()
         protected = {"alg": "HS256"}
         header = {"protected": protected, "header": {"kid": "a"}}
         s = jws.serialize(header, "hello", "secret")
-        self.assertIsInstance(s, dict)
+        assert isinstance(s, dict)
 
         data = jws.deserialize(s, "secret")
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "HS256")
-        self.assertNotIn("protected", data)
+        assert payload == b"hello"
+        assert header["alg"] == "HS256"
+        assert "protected" not in data
 
     def test_nested_json_jws(self):
         jws = JsonWebSignature()
         protected = {"alg": "HS256"}
         header = {"protected": protected, "header": {"kid": "a"}}
         s = jws.serialize([header], "hello", "secret")
-        self.assertIsInstance(s, dict)
-        self.assertIn("signatures", s)
+        assert isinstance(s, dict)
+        assert "signatures" in s
 
         data = jws.deserialize(s, "secret")
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header[0]["alg"], "HS256")
-        self.assertNotIn("signatures", data)
+        assert payload == b"hello"
+        assert header[0]["alg"] == "HS256"
+        assert "signatures" not in data
 
         # test bad signature
-        self.assertRaises(errors.BadSignatureError, jws.deserialize, s, "f")
+        with pytest.raises(errors.BadSignatureError):
+            jws.deserialize(s, "f")
 
     def test_function_key(self):
         protected = {"alg": "HS256"}
@@ -137,7 +142,7 @@ class JWSTest(unittest.TestCase):
         ]
 
         def load_key(header, payload):
-            self.assertEqual(payload, b"hello")
+            assert payload == b"hello"
             kid = header.get("kid")
             if kid == "a":
                 return "secret-a"
@@ -145,14 +150,14 @@ class JWSTest(unittest.TestCase):
 
         jws = JsonWebSignature()
         s = jws.serialize(header, b"hello", load_key)
-        self.assertIsInstance(s, dict)
-        self.assertIn("signatures", s)
+        assert isinstance(s, dict)
+        assert "signatures" in s
 
         data = jws.deserialize(json.dumps(s), load_key)
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header[0]["alg"], "HS256")
-        self.assertNotIn("signature", data)
+        assert payload == b"hello"
+        assert header[0]["alg"] == "HS256"
+        assert "signature" not in data
 
     def test_serialize_json_empty_payload(self):
         jws = JsonWebSignature()
@@ -160,53 +165,56 @@ class JWSTest(unittest.TestCase):
         header = {"protected": protected, "header": {"kid": "a"}}
         s = jws.serialize_json(header, b"", "secret")
         data = jws.deserialize_json(s, "secret")
-        self.assertEqual(data["payload"], b"")
+        assert data["payload"] == b""
 
     def test_fail_deserialize_json(self):
         jws = JsonWebSignature()
-        self.assertRaises(errors.DecodeError, jws.deserialize_json, None, "")
-        self.assertRaises(errors.DecodeError, jws.deserialize_json, "[]", "")
-        self.assertRaises(errors.DecodeError, jws.deserialize_json, "{}", "")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize_json(None, "")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize_json("[]", "")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize_json("{}", "")
 
         # missing protected
         s = json.dumps({"payload": "YQ"})
-        self.assertRaises(errors.DecodeError, jws.deserialize_json, s, "")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize_json(s, "")
 
         # missing signature
         s = json.dumps({"payload": "YQ", "protected": "YQ"})
-        self.assertRaises(errors.DecodeError, jws.deserialize_json, s, "")
+        with pytest.raises(errors.DecodeError):
+            jws.deserialize_json(s, "")
 
     def test_validate_header(self):
         jws = JsonWebSignature(private_headers=[])
         protected = {"alg": "HS256", "invalid": "k"}
         header = {"protected": protected, "header": {"kid": "a"}}
-        self.assertRaises(
-            errors.InvalidHeaderParameterNameError,
-            jws.serialize,
-            header,
-            b"hello",
-            "secret",
-        )
+        with pytest.raises(errors.InvalidHeaderParameterNameError):
+            jws.serialize(
+                header,
+                b"hello",
+                "secret",
+            )
         jws = JsonWebSignature(private_headers=["invalid"])
         s = jws.serialize(header, b"hello", "secret")
-        self.assertIsInstance(s, dict)
+        assert isinstance(s, dict)
 
         jws = JsonWebSignature()
         s = jws.serialize(header, b"hello", "secret")
-        self.assertIsInstance(s, dict)
+        assert isinstance(s, dict)
 
     def test_ES512_alg(self):
         jws = JsonWebSignature()
         private_key = read_file_path("secp521r1-private.json")
         public_key = read_file_path("secp521r1-public.json")
-        self.assertRaises(
-            ValueError, jws.serialize, {"alg": "ES256"}, "hello", private_key
-        )
+        with pytest.raises(ValueError):
+            jws.serialize({"alg": "ES256"}, "hello", private_key)
         s = jws.serialize({"alg": "ES512"}, "hello", private_key)
         data = jws.deserialize(s, public_key)
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "ES512")
+        assert payload == b"hello"
+        assert header["alg"] == "ES512"
 
     def test_ES256K_alg(self):
         jws = JsonWebSignature(algorithms=["ES256K"])
@@ -215,5 +223,5 @@ class JWSTest(unittest.TestCase):
         s = jws.serialize({"alg": "ES256K"}, "hello", private_key)
         data = jws.deserialize(s, public_key)
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "ES256K")
+        assert payload == b"hello"
+        assert header["alg"] == "ES256K"

--- a/tests/jose/test_jwt.py
+++ b/tests/jose/test_jwt.py
@@ -1,6 +1,8 @@
 import datetime
 import unittest
 
+import pytest
+
 from authlib.jose import JsonWebKey
 from authlib.jose import JsonWebToken
 from authlib.jose import JWTClaims
@@ -13,38 +15,34 @@ from tests.util import read_file_path
 class JWTTest(unittest.TestCase):
     def test_init_algorithms(self):
         _jwt = JsonWebToken(["RS256"])
-        self.assertRaises(
-            UnsupportedAlgorithmError, _jwt.encode, {"alg": "HS256"}, {}, "k"
-        )
+        with pytest.raises(UnsupportedAlgorithmError):
+            _jwt.encode({"alg": "HS256"}, {}, "k")
 
         _jwt = JsonWebToken("RS256")
-        self.assertRaises(
-            UnsupportedAlgorithmError, _jwt.encode, {"alg": "HS256"}, {}, "k"
-        )
+        with pytest.raises(UnsupportedAlgorithmError):
+            _jwt.encode({"alg": "HS256"}, {}, "k")
 
     def test_encode_sensitive_data(self):
         # check=False won't raise error
         jwt.encode({"alg": "HS256"}, {"password": ""}, "k", check=False)
-        self.assertRaises(
-            errors.InsecureClaimError,
-            jwt.encode,
-            {"alg": "HS256"},
-            {"password": ""},
-            "k",
-        )
-        self.assertRaises(
-            errors.InsecureClaimError,
-            jwt.encode,
-            {"alg": "HS256"},
-            {"text": "4242424242424242"},
-            "k",
-        )
+        with pytest.raises(errors.InsecureClaimError):
+            jwt.encode(
+                {"alg": "HS256"},
+                {"password": ""},
+                "k",
+            )
+        with pytest.raises(errors.InsecureClaimError):
+            jwt.encode(
+                {"alg": "HS256"},
+                {"text": "4242424242424242"},
+                "k",
+            )
 
     def test_encode_datetime(self):
         now = datetime.datetime.now(tz=datetime.timezone.utc)
         id_token = jwt.encode({"alg": "HS256"}, {"exp": now}, "k")
         claims = jwt.decode(id_token, "k")
-        self.assertIsInstance(claims.exp, int)
+        assert isinstance(claims.exp, int)
 
     def test_validate_essential_claims(self):
         id_token = jwt.encode({"alg": "HS256"}, {"iss": "foo"}, "k")
@@ -53,31 +51,30 @@ class JWTTest(unittest.TestCase):
         claims.validate()
 
         claims.options = {"sub": {"essential": True}}
-        self.assertRaises(errors.MissingClaimError, claims.validate)
+        with pytest.raises(errors.MissingClaimError):
+            claims.validate()
 
     def test_attribute_error(self):
         claims = JWTClaims({"iss": "foo"}, {"alg": "HS256"})
-        self.assertRaises(AttributeError, lambda: claims.invalid)
+        with pytest.raises(AttributeError):
+            claims.invalid  # noqa: B018
 
     def test_invalid_values(self):
         id_token = jwt.encode({"alg": "HS256"}, {"iss": "foo"}, "k")
         claims_options = {"iss": {"values": ["bar"]}}
         claims = jwt.decode(id_token, "k", claims_options=claims_options)
-        self.assertRaises(
-            errors.InvalidClaimError,
-            claims.validate,
-        )
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
         claims.options = {"iss": {"value": "bar"}}
-        self.assertRaises(
-            errors.InvalidClaimError,
-            claims.validate,
-        )
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
     def test_validate_expected_issuer_received_None(self):
         id_token = jwt.encode({"alg": "HS256"}, {"iss": None, "sub": None}, "k")
         claims_options = {"iss": {"essential": True, "values": ["foo"]}}
         claims = jwt.decode(id_token, "k", claims_options=claims_options)
-        self.assertRaises(errors.InvalidClaimError, claims.validate)
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
     def test_validate_aud(self):
         id_token = jwt.encode({"alg": "HS256"}, {"aud": "foo"}, "k")
@@ -86,7 +83,8 @@ class JWTTest(unittest.TestCase):
         claims.validate()
 
         claims.options = {"aud": {"values": ["bar"]}}
-        self.assertRaises(errors.InvalidClaimError, claims.validate)
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
         id_token = jwt.encode({"alg": "HS256"}, {"aud": ["foo", "bar"]}, "k")
         claims = jwt.decode(id_token, "k", claims_options=claims_options)
@@ -98,16 +96,19 @@ class JWTTest(unittest.TestCase):
     def test_validate_exp(self):
         id_token = jwt.encode({"alg": "HS256"}, {"exp": "invalid"}, "k")
         claims = jwt.decode(id_token, "k")
-        self.assertRaises(errors.InvalidClaimError, claims.validate)
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
         id_token = jwt.encode({"alg": "HS256"}, {"exp": 1234}, "k")
         claims = jwt.decode(id_token, "k")
-        self.assertRaises(errors.ExpiredTokenError, claims.validate)
+        with pytest.raises(errors.ExpiredTokenError):
+            claims.validate()
 
     def test_validate_nbf(self):
         id_token = jwt.encode({"alg": "HS256"}, {"nbf": "invalid"}, "k")
         claims = jwt.decode(id_token, "k")
-        self.assertRaises(errors.InvalidClaimError, claims.validate)
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
         id_token = jwt.encode({"alg": "HS256"}, {"nbf": 1234}, "k")
         claims = jwt.decode(id_token, "k")
@@ -115,7 +116,8 @@ class JWTTest(unittest.TestCase):
 
         id_token = jwt.encode({"alg": "HS256"}, {"nbf": 1234}, "k")
         claims = jwt.decode(id_token, "k")
-        self.assertRaises(errors.InvalidTokenError, claims.validate, 123)
+        with pytest.raises(errors.InvalidTokenError):
+            claims.validate(123)
 
     def test_validate_iat_issued_in_future(self):
         in_future = datetime.datetime.now(
@@ -123,12 +125,11 @@ class JWTTest(unittest.TestCase):
         ) + datetime.timedelta(seconds=10)
         id_token = jwt.encode({"alg": "HS256"}, {"iat": in_future}, "k")
         claims = jwt.decode(id_token, "k")
-        with self.assertRaises(errors.InvalidTokenError) as error_ctx:
+        with pytest.raises(
+            errors.InvalidTokenError,
+            match="The token is not valid as it was issued in the future",
+        ):
             claims.validate()
-        self.assertEqual(
-            str(error_ctx.exception),
-            "invalid_token: The token is not valid as it was issued in the future",
-        )
 
     def test_validate_iat_issued_in_future_with_insufficient_leeway(self):
         in_future = datetime.datetime.now(
@@ -136,12 +137,11 @@ class JWTTest(unittest.TestCase):
         ) + datetime.timedelta(seconds=10)
         id_token = jwt.encode({"alg": "HS256"}, {"iat": in_future}, "k")
         claims = jwt.decode(id_token, "k")
-        with self.assertRaises(errors.InvalidTokenError) as error_ctx:
+        with pytest.raises(
+            errors.InvalidTokenError,
+            match="The token is not valid as it was issued in the future",
+        ):
             claims.validate(leeway=5)
-        self.assertEqual(
-            str(error_ctx.exception),
-            "invalid_token: The token is not valid as it was issued in the future",
-        )
 
     def test_validate_iat_issued_in_future_with_sufficient_leeway(self):
         in_future = datetime.datetime.now(
@@ -162,29 +162,32 @@ class JWTTest(unittest.TestCase):
     def test_validate_iat(self):
         id_token = jwt.encode({"alg": "HS256"}, {"iat": "invalid"}, "k")
         claims = jwt.decode(id_token, "k")
-        self.assertRaises(errors.InvalidClaimError, claims.validate)
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
     def test_validate_jti(self):
         id_token = jwt.encode({"alg": "HS256"}, {"jti": "bar"}, "k")
         claims_options = {"jti": {"validate": lambda c, o: o == "foo"}}
         claims = jwt.decode(id_token, "k", claims_options=claims_options)
-        self.assertRaises(errors.InvalidClaimError, claims.validate)
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
     def test_validate_custom(self):
         id_token = jwt.encode({"alg": "HS256"}, {"custom": "foo"}, "k")
         claims_options = {"custom": {"validate": lambda c, o: o == "bar"}}
         claims = jwt.decode(id_token, "k", claims_options=claims_options)
-        self.assertRaises(errors.InvalidClaimError, claims.validate)
+        with pytest.raises(errors.InvalidClaimError):
+            claims.validate()
 
     def test_use_jws(self):
         payload = {"name": "hi"}
         private_key = read_file_path("rsa_private.pem")
         pub_key = read_file_path("rsa_public.pem")
         data = jwt.encode({"alg": "RS256"}, payload, private_key)
-        self.assertEqual(data.count(b"."), 2)
+        assert data.count(b".") == 2
 
         claims = jwt.decode(data, pub_key)
-        self.assertEqual(claims["name"], "hi")
+        assert claims["name"] == "hi"
 
     def test_use_jwe(self):
         payload = {"name": "hi"}
@@ -192,10 +195,10 @@ class JWTTest(unittest.TestCase):
         pub_key = read_file_path("rsa_public.pem")
         _jwt = JsonWebToken(["RSA-OAEP", "A256GCM"])
         data = _jwt.encode({"alg": "RSA-OAEP", "enc": "A256GCM"}, payload, pub_key)
-        self.assertEqual(data.count(b"."), 4)
+        assert data.count(b".") == 4
 
         claims = _jwt.decode(data, private_key)
-        self.assertEqual(claims["name"], "hi")
+        assert claims["name"] == "hi"
 
     def test_use_jwks(self):
         header = {"alg": "RS256", "kid": "abc"}
@@ -203,9 +206,9 @@ class JWTTest(unittest.TestCase):
         private_key = read_file_path("jwks_private.json")
         pub_key = read_file_path("jwks_public.json")
         data = jwt.encode(header, payload, private_key)
-        self.assertEqual(data.count(b"."), 2)
+        assert data.count(b".") == 2
         claims = jwt.decode(data, pub_key)
-        self.assertEqual(claims["name"], "hi")
+        assert claims["name"] == "hi"
 
     def test_use_jwks_single_kid(self):
         """Test that jwks can be decoded if a kid for decoding is given and encoded data has no kid and only one key is set."""
@@ -214,9 +217,9 @@ class JWTTest(unittest.TestCase):
         private_key = read_file_path("jwks_single_private.json")
         pub_key = read_file_path("jwks_single_public.json")
         data = jwt.encode(header, payload, private_key)
-        self.assertEqual(data.count(b"."), 2)
+        assert data.count(b".") == 2
         claims = jwt.decode(data, pub_key)
-        self.assertEqual(claims["name"], "hi")
+        assert claims["name"] == "hi"
 
     # Added a unit test to showcase my problem.
     # This calls jwt.decode similarly as is done in parse_id_token method of the AsyncOpenIDMixin class when the id token does not contain a kid in the alg header.
@@ -227,16 +230,16 @@ class JWTTest(unittest.TestCase):
         private_key = read_file_path("jwks_single_private.json")
         pub_key = read_file_path("jwks_single_public.json")
         data = jwt.encode(header, payload, private_key)
-        self.assertEqual(data.count(b"."), 2)
+        assert data.count(b".") == 2
         claims = jwt.decode(data, JsonWebKey.import_key_set(pub_key))
-        self.assertEqual(claims["name"], "hi")
+        assert claims["name"] == "hi"
 
     def test_with_ec(self):
         payload = {"name": "hi"}
         private_key = read_file_path("secp521r1-private.json")
         pub_key = read_file_path("secp521r1-public.json")
         data = jwt.encode({"alg": "ES512"}, payload, private_key)
-        self.assertEqual(data.count(b"."), 2)
+        assert data.count(b".") == 2
 
         claims = jwt.decode(data, pub_key)
-        self.assertEqual(claims["name"], "hi")
+        assert claims["name"] == "hi"

--- a/tests/jose/test_rfc8037.py
+++ b/tests/jose/test_rfc8037.py
@@ -12,5 +12,5 @@ class EdDSATest(unittest.TestCase):
         s = jws.serialize({"alg": "EdDSA"}, "hello", private_key)
         data = jws.deserialize(s, public_key)
         header, payload = data["header"], data["payload"]
-        self.assertEqual(payload, b"hello")
-        self.assertEqual(header["alg"], "EdDSA")
+        assert payload == b"hello"
+        assert header["alg"] == "EdDSA"


### PR DESCRIPTION
This PR adopts the pytest `assert x == y` style instead of unittest `self.assertEqual(x, y)`.

This makes the assertions more legible, without concessions on the error messages.