### PR TITLE
Implement RFC9101 JWT secured authentication requests (JAR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Generic, spec-compliant implementation to build clients and providers:
   - [RFC8414: OAuth 2.0 Authorization Server Metadata](https://docs.authlib.org/en/latest/specs/rfc8414.html)
   - [RFC8628: OAuth 2.0 Device Authorization Grant](https://docs.authlib.org/en/latest/specs/rfc8628.html)
   - [RFC9068: JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://docs.authlib.org/en/latest/specs/rfc9068.html)
+  - [RFC9101: The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)](https://docs.authlib.org/en/latest/specs/rfc9101.html)
   - [RFC9207: OAuth 2.0 Authorization Server Issuer Identification](https://docs.authlib.org/en/latest/specs/rfc9207.html)
 - [Javascript Object Signing and Encryption](https://docs.authlib.org/en/latest/jose/index.html)
   - [RFC7515: JSON Web Signature](https://docs.authlib.org/en/latest/jose/jws.html)

--- a/README.rst
+++ b/README.rst
@@ -30,12 +30,15 @@ Specifications
 - RFC7521: Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants
 - RFC7523: JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants
 - RFC7591: OAuth 2.0 Dynamic Client Registration Protocol
+- RFC7592: OAuth 2.0 Dynamic Client Registration Management Protocol
 - RFC7636: Proof Key for Code Exchange by OAuth Public Clients
 - RFC7638: JSON Web Key (JWK) Thumbprint
 - RFC7662: OAuth 2.0 Token Introspection
 - RFC8037: CFRG Elliptic Curve Diffie-Hellman (ECDH) and Signatures in JSON Object Signing and Encryption (JOSE)
 - RFC8414: OAuth 2.0 Authorization Server Metadata
 - RFC8628: OAuth 2.0 Device Authorization Grant
+- RFC9101: The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)
+- RFC9207: OAuth 2.0 Authorization Server Issuer Identification
 - OpenID Connect 1.0
 - OpenID Connect Discovery 1.0
 - draft-madden-jose-ecdh-1pu-04: Public Key Authenticated Encryption for JOSE: ECDH-1PU

--- a/authlib/deprecate.py
+++ b/authlib/deprecate.py
@@ -8,9 +8,11 @@ class AuthlibDeprecationWarning(DeprecationWarning):
 warnings.simplefilter("always", AuthlibDeprecationWarning)
 
 
-def deprecate(message, version=None, link_uid=None, link_file=None):
+def deprecate(message, version=None, link_uid=None, link_file=None, stacklevel=3):
     if version:
         message += f"\nIt will be compatible before version {version}."
+
     if link_uid and link_file:
         message += f"\nRead more <https://git.io/{link_uid}#file-{link_file}-md>"
-    warnings.warn(AuthlibDeprecationWarning(message), stacklevel=2)
+
+    warnings.warn(AuthlibDeprecationWarning(message), stacklevel=stacklevel)

--- a/authlib/integrations/django_oauth2/requests.py
+++ b/authlib/integrations/django_oauth2/requests.py
@@ -10,9 +10,7 @@ from authlib.oauth2.rfc6749 import OAuth2Request
 
 class DjangoOAuth2Request(OAuth2Request):
     def __init__(self, request: HttpRequest):
-        super().__init__(
-            request.method, request.build_absolute_uri(), None, request.headers
-        )
+        super().__init__(request.method, request.build_absolute_uri(), request.headers)
         self._request = request
 
     @property
@@ -42,9 +40,7 @@ class DjangoOAuth2Request(OAuth2Request):
 
 class DjangoJsonRequest(JsonRequest):
     def __init__(self, request: HttpRequest):
-        super().__init__(
-            request.method, request.build_absolute_uri(), None, request.headers
-        )
+        super().__init__(request.method, request.build_absolute_uri(), request.headers)
         self._request = request
 
     @cached_property

--- a/authlib/integrations/django_oauth2/requests.py
+++ b/authlib/integrations/django_oauth2/requests.py
@@ -4,22 +4,15 @@ from django.http import HttpRequest
 from django.utils.functional import cached_property
 
 from authlib.common.encoding import json_loads
+from authlib.oauth2.rfc6749 import JsonPayload
 from authlib.oauth2.rfc6749 import JsonRequest
+from authlib.oauth2.rfc6749 import OAuth2Payload
 from authlib.oauth2.rfc6749 import OAuth2Request
 
 
-class DjangoOAuth2Request(OAuth2Request):
+class DjangoOAuth2Payload(OAuth2Payload):
     def __init__(self, request: HttpRequest):
-        super().__init__(request.method, request.build_absolute_uri(), request.headers)
         self._request = request
-
-    @property
-    def args(self):
-        return self._request.GET
-
-    @property
-    def form(self):
-        return self._request.POST
 
     @cached_property
     def data(self):
@@ -31,18 +24,38 @@ class DjangoOAuth2Request(OAuth2Request):
     @cached_property
     def datalist(self):
         values = defaultdict(list)
-        for k in self.args:
-            values[k].extend(self.args.getlist(k))
-        for k in self.form:
-            values[k].extend(self.form.getlist(k))
+        for k in self._request.GET:
+            values[k].extend(self._request.GET.getlist(k))
+        for k in self._request.POST:
+            values[k].extend(self._request.POST.getlist(k))
         return values
 
 
-class DjangoJsonRequest(JsonRequest):
+class DjangoOAuth2Request(OAuth2Request):
     def __init__(self, request: HttpRequest):
         super().__init__(request.method, request.build_absolute_uri(), request.headers)
+        self.payload = DjangoOAuth2Payload(request)
+        self._request = request
+
+    @property
+    def args(self):
+        return self._request.GET
+
+    @property
+    def form(self):
+        return self._request.POST
+
+
+class DjangoJsonPayload(JsonPayload):
+    def __init__(self, request: HttpRequest):
         self._request = request
 
     @cached_property
     def data(self):
         return json_loads(self._request.body)
+
+
+class DjangoJsonRequest(JsonRequest):
+    def __init__(self, request: HttpRequest):
+        super().__init__(request.method, request.build_absolute_uri(), request.headers)
+        self.payload = DjangoJsonPayload(request)

--- a/authlib/integrations/flask_oauth2/requests.py
+++ b/authlib/integrations/flask_oauth2/requests.py
@@ -3,22 +3,15 @@ from functools import cached_property
 
 from flask.wrappers import Request
 
+from authlib.oauth2.rfc6749 import JsonPayload
 from authlib.oauth2.rfc6749 import JsonRequest
+from authlib.oauth2.rfc6749 import OAuth2Payload
 from authlib.oauth2.rfc6749 import OAuth2Request
 
 
-class FlaskOAuth2Request(OAuth2Request):
+class FlaskOAuth2Payload(OAuth2Payload):
     def __init__(self, request: Request):
-        super().__init__(request.method, request.url, request.headers)
         self._request = request
-
-    @property
-    def args(self):
-        return self._request.args
-
-    @property
-    def form(self):
-        return self._request.form
 
     @property
     def data(self):
@@ -32,11 +25,31 @@ class FlaskOAuth2Request(OAuth2Request):
         return values
 
 
-class FlaskJsonRequest(JsonRequest):
+class FlaskOAuth2Request(OAuth2Request):
     def __init__(self, request: Request):
         super().__init__(request.method, request.url, request.headers)
+        self._request = request
+        self.payload = FlaskOAuth2Payload(request)
+
+    @property
+    def args(self):
+        return self._request.args
+
+    @property
+    def form(self):
+        return self._request.form
+
+
+class FlaskJsonPayload(JsonPayload):
+    def __init__(self, request: Request):
         self._request = request
 
     @property
     def data(self):
         return self._request.get_json()
+
+
+class FlaskJsonRequest(JsonRequest):
+    def __init__(self, request: Request):
+        super().__init__(request.method, request.url, request.headers)
+        self.payload = FlaskJsonPayload(request)

--- a/authlib/integrations/flask_oauth2/requests.py
+++ b/authlib/integrations/flask_oauth2/requests.py
@@ -9,7 +9,7 @@ from authlib.oauth2.rfc6749 import OAuth2Request
 
 class FlaskOAuth2Request(OAuth2Request):
     def __init__(self, request: Request):
-        super().__init__(request.method, request.url, None, request.headers)
+        super().__init__(request.method, request.url, request.headers)
         self._request = request
 
     @property
@@ -34,7 +34,7 @@ class FlaskOAuth2Request(OAuth2Request):
 
 class FlaskJsonRequest(JsonRequest):
     def __init__(self, request: Request):
-        super().__init__(request.method, request.url, None, request.headers)
+        super().__init__(request.method, request.url, request.headers)
         self._request = request
 
     @property

--- a/authlib/oauth2/rfc6749/__init__.py
+++ b/authlib/oauth2/rfc6749/__init__.py
@@ -36,7 +36,9 @@ from .grants import TokenEndpointMixin
 from .models import AuthorizationCodeMixin
 from .models import ClientMixin
 from .models import TokenMixin
+from .requests import JsonPayload
 from .requests import JsonRequest
+from .requests import OAuth2Payload
 from .requests import OAuth2Request
 from .resource_protector import ResourceProtector
 from .resource_protector import TokenValidator
@@ -46,8 +48,10 @@ from .util import scope_to_list
 from .wrappers import OAuth2Token
 
 __all__ = [
+    "OAuth2Payload",
     "OAuth2Token",
     "OAuth2Request",
+    "JsonPayload",
     "JsonRequest",
     "OAuth2Error",
     "AccessDeniedError",

--- a/authlib/oauth2/rfc6749/authenticate_client.py
+++ b/authlib/oauth2/rfc6749/authenticate_client.py
@@ -89,8 +89,8 @@ def authenticate_none(query_client, request):
     """Authenticate public client by ``none`` method. The client
     does not have a client secret.
     """
-    client_id = request.client_id
-    if client_id and not request.data.get("client_secret"):
+    client_id = request.payload.client_id
+    if client_id and not request.payload.data.get("client_secret"):
         client = _validate_client(query_client, client_id)
         log.debug(f'Authenticate {client_id} via "none" success')
         return client

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -311,7 +311,7 @@ class AuthorizationServer(Hookable):
             request = self.create_oauth2_request(request)
 
         if not grant:
-            deprecate("The 'grant' parameter will become mandatory.", version="1.7")
+            deprecate("The 'grant' parameter will become mandatory.", version="1.8")
             try:
                 grant = self.get_authorization_grant(request)
             except UnsupportedResponseTypeError as error:

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -1,4 +1,5 @@
 from authlib.common.errors import ContinueIteration
+from authlib.deprecate import deprecate
 
 from .authenticate_client import ClientAuthentication
 from .errors import InvalidScopeError
@@ -289,7 +290,7 @@ class AuthorizationServer:
             except OAuth2Error as error:
                 return self.handle_error_response(request, error)
 
-    def create_authorization_response(self, request=None, grant_user=None):
+    def create_authorization_response(self, request=None, grant_user=None, grant=None):
         """Validate authorization request and create authorization response.
 
         :param request: HTTP request instance.
@@ -300,11 +301,13 @@ class AuthorizationServer:
         if not isinstance(request, OAuth2Request):
             request = self.create_oauth2_request(request)
 
-        try:
-            grant = self.get_authorization_grant(request)
-        except UnsupportedResponseTypeError as error:
-            error.state = request.state
-            return self.handle_error_response(request, error)
+        if not grant:
+            deprecate("The 'grant' parameter will become mandatory.", version="1.7")
+            try:
+                grant = self.get_authorization_grant(request)
+            except UnsupportedResponseTypeError as error:
+                error.state = request.state
+                return self.handle_error_response(request, error)
 
         try:
             redirect_uri = grant.validate_authorization_request()

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -230,6 +230,7 @@ class AuthorizationServer(Hookable):
         endpoints = self._endpoints.setdefault(endpoint.ENDPOINT_NAME, [])
         endpoints.append(endpoint)
 
+    @hooked
     def get_authorization_grant(self, request):
         """Find the authorization grant for current request.
 

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -234,9 +234,9 @@ class AuthorizationServer:
                 return _create_grant(grant_cls, extensions, request, self)
 
         raise UnsupportedResponseTypeError(
-            f"The response type '{request.response_type}' is not supported by the server.",
-            request.response_type,
-            redirect_uri=request.redirect_uri,
+            f"The response type '{request.payload.response_type}' is not supported by the server.",
+            request.payload.response_type,
+            redirect_uri=request.payload.redirect_uri,
         )
 
     def get_consent_grant(self, request=None, end_user=None):
@@ -255,7 +255,7 @@ class AuthorizationServer:
             # REQUIRED if a "state" parameter was present in the client
             # authorization request.  The exact value received from the
             # client.
-            error.state = request.state
+            error.state = request.payload.state
             raise
         return grant
 
@@ -268,7 +268,7 @@ class AuthorizationServer:
         for grant_cls, extensions in self._token_grants:
             if grant_cls.check_token_endpoint(request):
                 return _create_grant(grant_cls, extensions, request, self)
-        raise UnsupportedGrantTypeError(request.grant_type)
+        raise UnsupportedGrantTypeError(request.payload.grant_type)
 
     def create_endpoint_response(self, name, request=None):
         """Validate endpoint request and create endpoint response.
@@ -306,7 +306,7 @@ class AuthorizationServer:
             try:
                 grant = self.get_authorization_grant(request)
             except UnsupportedResponseTypeError as error:
-                error.state = request.state
+                error.state = request.payload.state
                 return self.handle_error_response(request, error)
 
         try:
@@ -314,7 +314,7 @@ class AuthorizationServer:
             args = grant.create_authorization_response(redirect_uri, grant_user)
             response = self.handle_response(*args)
         except OAuth2Error as error:
-            error.state = request.state
+            error.state = request.payload.state
             response = self.handle_error_response(request, error)
 
         grant.execute_hook("after_authorization_response", response)

--- a/authlib/oauth2/rfc6749/grants/authorization_code.py
+++ b/authlib/oauth2/rfc6749/grants/authorization_code.py
@@ -158,8 +158,8 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
         self.save_authorization_code(code, self.request)
 
         params = [("code", code)]
-        if self.request.state:
-            params.append(("state", self.request.state))
+        if self.request.payload.state:
+            params.append(("state", self.request.payload.state))
         uri = add_params_to_uri(redirect_uri, params)
         headers = [("Location", uri)]
         return 302, "", headers
@@ -229,7 +229,7 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
 
         # validate redirect_uri parameter
         log.debug("Validate token redirect_uri of %r", client)
-        redirect_uri = self.request.redirect_uri
+        redirect_uri = self.request.payload.redirect_uri
         original_redirect_uri = authorization_code.get_redirect_uri()
         if original_redirect_uri and redirect_uri != original_redirect_uri:
             raise InvalidGrantError("Invalid 'redirect_uri' in request.")
@@ -306,8 +306,8 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
                 item = AuthorizationCode(
                     code=code,
                     client_id=client.client_id,
-                    redirect_uri=request.redirect_uri,
-                    scope=request.scope,
+                    redirect_uri=request.payload.redirect_uri,
+                    scope=request.payload.scope,
                     user_id=request.user.id,
                 )
                 item.save()
@@ -353,7 +353,7 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
 
 def validate_code_authorization_request(grant):
     request = grant.request
-    client_id = request.client_id
+    client_id = request.payload.client_id
     log.debug("Validate authorization request of %r", client_id)
 
     if client_id is None:
@@ -368,7 +368,7 @@ def validate_code_authorization_request(grant):
         )
 
     redirect_uri = grant.validate_authorization_redirect_uri(request, client)
-    response_type = request.response_type
+    response_type = request.payload.response_type
     if not client.check_response_type(response_type):
         raise UnauthorizedClientError(
             f"The client is not authorized to use 'response_type={response_type}'",

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -1,10 +1,12 @@
 from authlib.consts import default_json_headers
 
 from ..errors import InvalidRequestError
+from ..hooks import Hookable
+from ..hooks import hooked
 from ..requests import OAuth2Request
 
 
-class BaseGrant:
+class BaseGrant(Hookable):
     #: Allowed client auth methods for token endpoint
     TOKEN_ENDPOINT_AUTH_METHODS = ["client_secret_basic"]
 
@@ -18,17 +20,11 @@ class BaseGrant:
     TOKEN_RESPONSE_HEADER = default_json_headers
 
     def __init__(self, request: OAuth2Request, server):
+        super().__init__()
         self.prompt = None
         self.redirect_uri = None
         self.request = request
         self.server = server
-        self._hooks = {
-            "after_validate_authorization_request": set(),
-            "after_authorization_response": set(),
-            "after_validate_consent_request": set(),
-            "after_validate_token_request": set(),
-            "process_token": set(),
-        }
 
     @property
     def client(self):
@@ -87,15 +83,6 @@ class BaseGrant:
         """Validate if requested scope is supported by Authorization Server."""
         scope = self.request.payload.scope
         return self.server.validate_requested_scope(scope)
-
-    def register_hook(self, hook_type, hook):
-        if hook_type not in self._hooks:
-            raise ValueError("Hook type %s is not in %s.", hook_type, self._hooks)
-        self._hooks[hook_type].add(hook)
-
-    def execute_hook(self, hook_type, *args, **kwargs):
-        for hook in self._hooks[hook_type]:
-            hook(self, *args, **kwargs)
 
 
 class TokenEndpointMixin:
@@ -158,10 +145,11 @@ class AuthorizationEndpointMixin:
                     f"Multiple '{param}' in request.", state=request.payload.state
                 )
 
+    @hooked
     def validate_consent_request(self):
         redirect_uri = self.validate_authorization_request()
-        self.execute_hook("after_validate_consent_request", redirect_uri)
         self.redirect_uri = redirect_uri
+        return redirect_uri
 
     def validate_authorization_request(self):
         raise NotImplementedError()

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -85,7 +85,7 @@ class BaseGrant:
 
     def validate_requested_scope(self):
         """Validate if requested scope is supported by Authorization Server."""
-        scope = self.request.scope
+        scope = self.request.payload.scope
         return self.server.validate_requested_scope(scope)
 
     def register_hook(self, hook_type, hook):
@@ -108,7 +108,7 @@ class TokenEndpointMixin:
     @classmethod
     def check_token_endpoint(cls, request: OAuth2Request):
         return (
-            request.grant_type == cls.GRANT_TYPE
+            request.payload.grant_type == cls.GRANT_TYPE
             and request.method in cls.TOKEN_ENDPOINT_HTTP_METHODS
         )
 
@@ -125,21 +125,21 @@ class AuthorizationEndpointMixin:
 
     @classmethod
     def check_authorization_endpoint(cls, request: OAuth2Request):
-        return request.response_type in cls.RESPONSE_TYPES
+        return request.payload.response_type in cls.RESPONSE_TYPES
 
     @staticmethod
     def validate_authorization_redirect_uri(request: OAuth2Request, client):
-        if request.redirect_uri:
-            if not client.check_redirect_uri(request.redirect_uri):
+        if request.payload.redirect_uri:
+            if not client.check_redirect_uri(request.payload.redirect_uri):
                 raise InvalidRequestError(
-                    f"Redirect URI {request.redirect_uri} is not supported by client.",
+                    f"Redirect URI {request.payload.redirect_uri} is not supported by client.",
                 )
-            return request.redirect_uri
+            return request.payload.redirect_uri
         else:
             redirect_uri = client.get_default_redirect_uri()
             if not redirect_uri:
                 raise InvalidRequestError(
-                    "Missing 'redirect_uri' in request.", state=request.state
+                    "Missing 'redirect_uri' in request.", state=request.payload.state
                 )
             return redirect_uri
 
@@ -150,12 +150,12 @@ class AuthorizationEndpointMixin:
 
         .. _`Section 3.1`: https://tools.ietf.org/html/rfc6749#section-3.1
         """
-        datalist = request.datalist
+        datalist = request.payload.datalist
         parameters = ["response_type", "client_id", "redirect_uri", "scope", "state"]
         for param in parameters:
             if len(datalist.get(param, [])) > 1:
                 raise InvalidRequestError(
-                    f"Multiple '{param}' in request.", state=request.state
+                    f"Multiple '{param}' in request.", state=request.payload.state
                 )
 
     def validate_consent_request(self):

--- a/authlib/oauth2/rfc6749/grants/client_credentials.py
+++ b/authlib/oauth2/rfc6749/grants/client_credentials.py
@@ -100,7 +100,7 @@ class ClientCredentialsGrant(BaseGrant, TokenEndpointMixin):
         :returns: (status_code, body, headers)
         """
         token = self.generate_token(
-            scope=self.request.scope, include_refresh_token=False
+            scope=self.request.payload.scope, include_refresh_token=False
         )
         log.debug("Issue token %r to %r", token, self.client)
         self.save_token(token)

--- a/authlib/oauth2/rfc6749/grants/client_credentials.py
+++ b/authlib/oauth2/rfc6749/grants/client_credentials.py
@@ -1,6 +1,7 @@
 import logging
 
 from ..errors import UnauthorizedClientError
+from ..hooks import hooked
 from .base import BaseGrant
 from .base import TokenEndpointMixin
 
@@ -74,6 +75,7 @@ class ClientCredentialsGrant(BaseGrant, TokenEndpointMixin):
         self.request.client = client
         self.validate_requested_scope()
 
+    @hooked
     def create_token_response(self):
         """If the access token request is valid and authorized, the
         authorization server issues an access token as described in
@@ -104,5 +106,4 @@ class ClientCredentialsGrant(BaseGrant, TokenEndpointMixin):
         )
         log.debug("Issue token %r to %r", token, self.client)
         self.save_token(token)
-        self.execute_hook("process_token", self, token=token)
         return 200, token, self.TOKEN_RESPONSE_HEADER

--- a/authlib/oauth2/rfc6749/grants/implicit.py
+++ b/authlib/oauth2/rfc6749/grants/implicit.py
@@ -127,7 +127,7 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
 
         redirect_uri = self.validate_authorization_redirect_uri(self.request, client)
 
-        response_type = self.request.response_type
+        response_type = self.request.payload.response_type
         if not client.check_response_type(response_type):
             raise UnauthorizedClientError(
                 f"The client is not authorized to use 'response_type={response_type}'",
@@ -201,12 +201,12 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
             resource owner, otherwise pass None.
         :returns: (status_code, body, headers)
         """
-        state = self.request.state
+        state = self.request.payload.state
         if grant_user:
             self.request.user = grant_user
             token = self.generate_token(
                 user=grant_user,
-                scope=self.request.scope,
+                scope=self.request.payload.scope,
                 include_refresh_token=False,
             )
             log.debug("Grant token %r to %r", token, self.request.client)

--- a/authlib/oauth2/rfc6749/grants/implicit.py
+++ b/authlib/oauth2/rfc6749/grants/implicit.py
@@ -5,6 +5,7 @@ from authlib.common.urls import add_params_to_uri
 from ..errors import AccessDeniedError
 from ..errors import OAuth2Error
 from ..errors import UnauthorizedClientError
+from ..hooks import hooked
 from .base import AuthorizationEndpointMixin
 from .base import BaseGrant
 
@@ -77,6 +78,7 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
     GRANT_TYPE = "implicit"
     ERROR_RESPONSE_FRAGMENT = True
 
+    @hooked
     def validate_authorization_request(self):
         """The client constructs the request URI by adding the following
         parameters to the query component of the authorization endpoint URI
@@ -138,13 +140,13 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
         try:
             self.request.client = client
             self.validate_requested_scope()
-            self.execute_hook("after_validate_authorization_request")
         except OAuth2Error as error:
             error.redirect_uri = redirect_uri
             error.redirect_fragment = True
             raise error
         return redirect_uri
 
+    @hooked
     def create_authorization_response(self, redirect_uri, grant_user):
         """If the resource owner grants the access request, the authorization
         server issues an access token and delivers it to the client by adding
@@ -212,7 +214,6 @@ class ImplicitGrant(BaseGrant, AuthorizationEndpointMixin):
             log.debug("Grant token %r to %r", token, self.request.client)
 
             self.save_token(token)
-            self.execute_hook("process_token", token=token)
             params = [(k, token[k]) for k in token]
             if state:
                 params.append(("state", state))

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -57,7 +57,7 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
         return token
 
     def _validate_token_scope(self, token):
-        scope = self.request.scope
+        scope = self.request.payload.scope
         if not scope:
             return
 
@@ -131,7 +131,7 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
         return 200, token, self.TOKEN_RESPONSE_HEADER
 
     def issue_token(self, user, refresh_token):
-        scope = self.request.scope
+        scope = self.request.payload.scope
         if not scope:
             scope = refresh_token.get_scope()
 

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -13,6 +13,7 @@ from ..errors import InvalidGrantError
 from ..errors import InvalidRequestError
 from ..errors import InvalidScopeError
 from ..errors import UnauthorizedClientError
+from ..hooks import hooked
 from ..util import scope_to_list
 from .base import BaseGrant
 from .base import TokenEndpointMixin
@@ -109,6 +110,7 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
         self._validate_token_scope(refresh_token)
         self.request.refresh_token = refresh_token
 
+    @hooked
     def create_token_response(self):
         """If valid and authorized, the authorization server issues an access
         token as described in Section 5.1.  If the request failed
@@ -126,7 +128,6 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
 
         self.request.user = user
         self.save_token(token)
-        self.execute_hook("process_token", token=token)
         self.revoke_old_credential(refresh_token)
         return 200, token, self.TOKEN_RESPONSE_HEADER
 

--- a/authlib/oauth2/rfc6749/grants/resource_owner_password_credentials.py
+++ b/authlib/oauth2/rfc6749/grants/resource_owner_password_credentials.py
@@ -135,7 +135,7 @@ class ResourceOwnerPasswordCredentialsGrant(BaseGrant, TokenEndpointMixin):
         :returns: (status_code, body, headers)
         """
         user = self.request.user
-        scope = self.request.scope
+        scope = self.request.payload.scope
         token = self.generate_token(user=user, scope=scope)
         log.debug("Issue token %r to %r", token, self.client)
         self.save_token(token)

--- a/authlib/oauth2/rfc6749/grants/resource_owner_password_credentials.py
+++ b/authlib/oauth2/rfc6749/grants/resource_owner_password_credentials.py
@@ -2,6 +2,7 @@ import logging
 
 from ..errors import InvalidRequestError
 from ..errors import UnauthorizedClientError
+from ..hooks import hooked
 from .base import BaseGrant
 from .base import TokenEndpointMixin
 
@@ -108,6 +109,7 @@ class ResourceOwnerPasswordCredentialsGrant(BaseGrant, TokenEndpointMixin):
         self.request.user = user
         self.validate_requested_scope()
 
+    @hooked
     def create_token_response(self):
         """If the access token request is valid and authorized, the
         authorization server issues an access token and optional refresh
@@ -139,7 +141,6 @@ class ResourceOwnerPasswordCredentialsGrant(BaseGrant, TokenEndpointMixin):
         token = self.generate_token(user=user, scope=scope)
         log.debug("Issue token %r to %r", token, self.client)
         self.save_token(token)
-        self.execute_hook("process_token", token=token)
         return 200, token, self.TOKEN_RESPONSE_HEADER
 
     def authenticate_user(self, username, password):

--- a/authlib/oauth2/rfc6749/hooks.py
+++ b/authlib/oauth2/rfc6749/hooks.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+
+
+class Hookable:
+    _hooks = None
+
+    def __init__(self):
+        self._hooks = defaultdict(set)
+
+    def register_hook(self, hook_type, hook):
+        self._hooks[hook_type].add(hook)
+
+    def execute_hook(self, hook_type, *args, **kwargs):
+        for hook in self._hooks[hook_type]:
+            hook(self, *args, **kwargs)
+
+
+def hooked(func=None, before=None, after=None):
+    """Execute hooks before and after the decorated method."""
+
+    def decorator(func):
+        before_name = before or f"before_{func.__name__}"
+        after_name = after or f"after_{func.__name__}"
+
+        def wrapper(self, *args, **kwargs):
+            self.execute_hook(before_name, *args, **kwargs)
+            result = func(self, *args, **kwargs)
+            self.execute_hook(after_name, result)
+            return result
+
+        return wrapper
+
+    # The decorator has been called without parenthesis
+    if callable(func):
+        return decorator(func)
+
+    return decorator

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -1,19 +1,14 @@
 from collections import defaultdict
 
-from authlib.common.encoding import json_loads
-from authlib.common.urls import url_decode
-from authlib.common.urls import urlparse
-
 from .errors import InsecureTransportError
 
 
 class OAuth2Request:
-    def __init__(self, method: str, uri: str, body=None, headers=None):
+    def __init__(self, method: str, uri: str, headers=None):
         InsecureTransportError.check(uri)
         #: HTTP method
         self.method = method
         self.uri = uri
-        self.body = body
         #: HTTP headers
         self.headers = headers or {}
 
@@ -24,38 +19,21 @@ class OAuth2Request:
         self.refresh_token = None
         self.credential = None
 
-        self._parsed_query = None
-
     @property
     def args(self):
-        if self._parsed_query is None:
-            self._parsed_query = url_decode(urlparse.urlparse(self.uri).query)
-        return dict(self._parsed_query)
+        raise NotImplementedError()
 
     @property
     def form(self):
-        return self.body or {}
+        raise NotImplementedError()
 
     @property
     def data(self):
-        data = {}
-        data.update(self.args)
-        data.update(self.form)
-        return data
+        raise NotImplementedError()
 
     @property
     def datalist(self) -> defaultdict[str, list]:
-        """Return all the data in query parameters and the body of the request as a dictionary
-        with all the values in lists.
-        """
-        if self._parsed_query is None:
-            self._parsed_query = url_decode(urlparse.urlparse(self.uri).query)
-        values = defaultdict(list)
-        for k, v in self._parsed_query:
-            values[k].append(v)
-        for k, v in self.form.items():
-            values[k].append(v)
-        return values
+        raise NotImplementedError()
 
     @property
     def client_id(self) -> str:
@@ -94,12 +72,11 @@ class OAuth2Request:
 
 
 class JsonRequest:
-    def __init__(self, method, uri, body=None, headers=None):
+    def __init__(self, method, uri, headers=None):
         self.method = method
         self.uri = uri
-        self.body = body
         self.headers = headers or {}
 
     @property
     def data(self):
-        return json_loads(self.body)
+        raise NotImplementedError()

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -1,32 +1,11 @@
 from collections import defaultdict
 
+from authlib.deprecate import deprecate
+
 from .errors import InsecureTransportError
 
 
-class OAuth2Request:
-    def __init__(self, method: str, uri: str, headers=None):
-        InsecureTransportError.check(uri)
-        #: HTTP method
-        self.method = method
-        self.uri = uri
-        #: HTTP headers
-        self.headers = headers or {}
-
-        self.client = None
-        self.auth_method = None
-        self.user = None
-        self.authorization_code = None
-        self.refresh_token = None
-        self.credential = None
-
-    @property
-    def args(self):
-        raise NotImplementedError()
-
-    @property
-    def form(self):
-        raise NotImplementedError()
-
+class OAuth2Payload:
     @property
     def data(self):
         raise NotImplementedError()
@@ -56,7 +35,7 @@ class OAuth2Request:
 
     @property
     def grant_type(self) -> str:
-        return self.form.get("grant_type")
+        return self.data.get("grant_type")
 
     @property
     def redirect_uri(self):
@@ -71,12 +50,114 @@ class OAuth2Request:
         return self.data.get("state")
 
 
+class OAuth2Request(OAuth2Payload):
+    def __init__(self, method: str, uri: str, headers=None):
+        InsecureTransportError.check(uri)
+        #: HTTP method
+        self.method = method
+        self.uri = uri
+        #: HTTP headers
+        self.headers = headers or {}
+
+        self.payload = None
+
+        self.client = None
+        self.auth_method = None
+        self.user = None
+        self.authorization_code = None
+        self.refresh_token = None
+        self.credential = None
+
+    @property
+    def args(self):
+        raise NotImplementedError()
+
+    @property
+    def form(self):
+        raise NotImplementedError()
+
+    @property
+    def data(self):
+        deprecate(
+            "'request.data' is deprecated in favor of 'request.payload.data'",
+            version="1.7",
+        )
+        return self.payload.data
+
+    @property
+    def datalist(self) -> defaultdict[str, list]:
+        deprecate(
+            "'request.datalist' is deprecated in favor of 'request.payload.datalist'",
+            version="1.7",
+        )
+        return self.payload.datalist
+
+    @property
+    def client_id(self) -> str:
+        deprecate(
+            "'request.client_id' is deprecated in favor of 'request.payload.client_id'",
+            version="1.7",
+        )
+        return self.payload.client_id
+
+    @property
+    def response_type(self) -> str:
+        deprecate(
+            "'request.response_type' is deprecated in favor of 'request.payload.response_type'",
+            version="1.7",
+        )
+        return self.payload.response_type
+
+    @property
+    def grant_type(self) -> str:
+        deprecate(
+            "'request.grant_type' is deprecated in favor of 'request.payload.grant_type'",
+            version="1.7",
+        )
+        return self.payload.grant_type
+
+    @property
+    def redirect_uri(self):
+        deprecate(
+            "'request.redirect_uri' is deprecated in favor of 'request.payload.redirect_uri'",
+            version="1.7",
+        )
+        return self.payload.redirect_uri
+
+    @property
+    def scope(self) -> str:
+        deprecate(
+            "'request.scope' is deprecated in favor of 'request.payload.scope'",
+            version="1.7",
+        )
+        return self.payload.scope
+
+    @property
+    def state(self):
+        deprecate(
+            "'request.state' is deprecated in favor of 'request.payload.state'",
+            version="1.7",
+        )
+        return self.payload.state
+
+
+class JsonPayload:
+    @property
+    def data(self):
+        raise NotImplementedError()
+
+
 class JsonRequest:
     def __init__(self, method, uri, headers=None):
         self.method = method
         self.uri = uri
         self.headers = headers or {}
+        self.payload = None
 
     @property
     def data(self):
-        raise NotImplementedError()
+        deprecate(
+            "'request.data' is deprecated in favor of 'request.payload.data'",
+            version="1.7",
+        )
+        return self.payload.data

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -94,7 +94,7 @@ class OAuth2Request(OAuth2Payload):
     def data(self):
         deprecate(
             "'request.data' is deprecated in favor of 'request.payload.data'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.data
 
@@ -102,7 +102,7 @@ class OAuth2Request(OAuth2Payload):
     def datalist(self) -> defaultdict[str, list]:
         deprecate(
             "'request.datalist' is deprecated in favor of 'request.payload.datalist'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.datalist
 
@@ -110,7 +110,7 @@ class OAuth2Request(OAuth2Payload):
     def client_id(self) -> str:
         deprecate(
             "'request.client_id' is deprecated in favor of 'request.payload.client_id'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.client_id
 
@@ -118,7 +118,7 @@ class OAuth2Request(OAuth2Payload):
     def response_type(self) -> str:
         deprecate(
             "'request.response_type' is deprecated in favor of 'request.payload.response_type'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.response_type
 
@@ -126,7 +126,7 @@ class OAuth2Request(OAuth2Payload):
     def grant_type(self) -> str:
         deprecate(
             "'request.grant_type' is deprecated in favor of 'request.payload.grant_type'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.grant_type
 
@@ -134,7 +134,7 @@ class OAuth2Request(OAuth2Payload):
     def redirect_uri(self):
         deprecate(
             "'request.redirect_uri' is deprecated in favor of 'request.payload.redirect_uri'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.redirect_uri
 
@@ -142,7 +142,7 @@ class OAuth2Request(OAuth2Payload):
     def scope(self) -> str:
         deprecate(
             "'request.scope' is deprecated in favor of 'request.payload.scope'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.scope
 
@@ -150,7 +150,7 @@ class OAuth2Request(OAuth2Payload):
     def state(self):
         deprecate(
             "'request.state' is deprecated in favor of 'request.payload.state'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.state
 
@@ -172,6 +172,6 @@ class JsonRequest:
     def data(self):
         deprecate(
             "'request.data' is deprecated in favor of 'request.payload.data'",
-            version="1.7",
+            version="1.8",
         )
         return self.payload.data

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -50,6 +50,20 @@ class OAuth2Payload:
         return self.data.get("state")
 
 
+class BasicOAuth2Payload(OAuth2Payload):
+    def __init__(self, payload):
+        self._data = payload
+        self._datalist = {key: [value] for key, value in payload.items()}
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def datalist(self) -> defaultdict[str, list]:
+        return self._datalist
+
+
 class OAuth2Request(OAuth2Payload):
     def __init__(self, method: str, uri: str, headers=None):
         InsecureTransportError.check(uri)

--- a/authlib/oauth2/rfc7523/jwt_bearer.py
+++ b/authlib/oauth2/rfc7523/jwt_bearer.py
@@ -134,7 +134,7 @@ class JWTBearerGrant(BaseGrant, TokenEndpointMixin):
         token.
         """
         token = self.generate_token(
-            scope=self.request.scope,
+            scope=self.request.payload.scope,
             user=self.request.user,
             include_refresh_token=False,
         )

--- a/authlib/oauth2/rfc7591/endpoint.py
+++ b/authlib/oauth2/rfc7591/endpoint.py
@@ -52,10 +52,10 @@ class ClientRegistrationEndpoint:
         return 201, body, default_json_headers
 
     def extract_client_metadata(self, request):
-        if not request.data:
+        if not request.payload.data:
             raise InvalidRequestError()
 
-        json_data = request.data.copy()
+        json_data = request.payload.data.copy()
         software_statement = json_data.pop("software_statement", None)
         if software_statement and self.software_statement_alg_values_supported:
             data = self.extract_software_statement(software_statement, request)

--- a/authlib/oauth2/rfc7591/endpoint.py
+++ b/authlib/oauth2/rfc7591/endpoint.py
@@ -66,7 +66,7 @@ class ClientRegistrationEndpoint:
         for claims_class in self.claims_classes:
             options = (
                 claims_class.get_claims_options(server_metadata)
-                if server_metadata
+                if hasattr(claims_class, "get_claims_options") and server_metadata
                 else {}
             )
             claims = claims_class(json_data, {}, options, server_metadata)

--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -110,7 +110,7 @@ class ClientConfigurationEndpoint:
         for claims_class in self.claims_classes:
             options = (
                 claims_class.get_claims_options(server_metadata)
-                if server_metadata
+                if hasattr(claims_class, "get_claims_options") and server_metadata
                 else {}
             )
             claims = claims_class(json_data, {}, options, server_metadata)

--- a/authlib/oauth2/rfc7592/endpoint.py
+++ b/authlib/oauth2/rfc7592/endpoint.py
@@ -82,11 +82,11 @@ class ClientConfigurationEndpoint:
             "client_id_issued_at",
         )
         for k in must_not_include:
-            if k in request.data:
+            if k in request.payload.data:
                 raise InvalidRequestError()
 
         # The client MUST include its 'client_id' field in the request
-        client_id = request.data.get("client_id")
+        client_id = request.payload.data.get("client_id")
         if not client_id:
             raise InvalidRequestError()
         if client_id != client.get_client_id():
@@ -95,8 +95,8 @@ class ClientConfigurationEndpoint:
         # If the client includes the 'client_secret' field in the request,
         # the value of this field MUST match the currently issued client
         # secret for that client.
-        if "client_secret" in request.data:
-            if not client.check_client_secret(request.data["client_secret"]):
+        if "client_secret" in request.payload.data:
+            if not client.check_client_secret(request.payload.data["client_secret"]):
                 raise InvalidRequestError()
 
         client_metadata = self.extract_client_metadata(request)
@@ -104,7 +104,7 @@ class ClientConfigurationEndpoint:
         return self.create_read_client_response(client, request)
 
     def extract_client_metadata(self, request):
-        json_data = request.data.copy()
+        json_data = request.payload.data.copy()
         client_metadata = {}
         server_metadata = self.get_server_metadata()
         for claims_class in self.claims_classes:
@@ -160,7 +160,7 @@ class ClientConfigurationEndpoint:
         Developers MUST implement this method in subclass::
 
             def authenticate_client(self, request):
-                client_id = request.data.get("client_id")
+                client_id = request.payload.data.get("client_id")
                 return Client.get(client_id=client_id)
 
         :return: client instance

--- a/authlib/oauth2/rfc7636/challenge.py
+++ b/authlib/oauth2/rfc7636/challenge.py
@@ -68,15 +68,15 @@ class CodeChallenge:
 
     def validate_code_challenge(self, grant):
         request: OAuth2Request = grant.request
-        challenge = request.data.get("code_challenge")
-        method = request.data.get("code_challenge_method")
+        challenge = request.payload.data.get("code_challenge")
+        method = request.payload.data.get("code_challenge_method")
         if not challenge and not method:
             return
 
         if not challenge:
             raise InvalidRequestError("Missing 'code_challenge'")
 
-        if len(request.datalist.get("code_challenge", [])) > 1:
+        if len(request.payload.datalist.get("code_challenge", [])) > 1:
             raise InvalidRequestError("Multiple 'code_challenge' in request.")
 
         if not CODE_CHALLENGE_PATTERN.match(challenge):
@@ -85,7 +85,7 @@ class CodeChallenge:
         if method and method not in self.SUPPORTED_CODE_CHALLENGE_METHOD:
             raise InvalidRequestError("Unsupported 'code_challenge_method'")
 
-        if len(request.datalist.get("code_challenge_method", [])) > 1:
+        if len(request.payload.datalist.get("code_challenge_method", [])) > 1:
             raise InvalidRequestError("Multiple 'code_challenge_method' in request.")
 
     def validate_code_verifier(self, grant):

--- a/authlib/oauth2/rfc7636/challenge.py
+++ b/authlib/oauth2/rfc7636/challenge.py
@@ -58,7 +58,7 @@ class CodeChallenge:
 
     def __call__(self, grant):
         grant.register_hook(
-            "after_validate_authorization_request",
+            "after_validate_authorization_request_payload",
             self.validate_code_challenge,
         )
         grant.register_hook(
@@ -66,7 +66,7 @@ class CodeChallenge:
             self.validate_code_verifier,
         )
 
-    def validate_code_challenge(self, grant):
+    def validate_code_challenge(self, grant, redirect_uri):
         request: OAuth2Request = grant.request
         challenge = request.payload.data.get("code_challenge")
         method = request.payload.data.get("code_challenge_method")
@@ -88,7 +88,7 @@ class CodeChallenge:
         if len(request.payload.datalist.get("code_challenge_method", [])) > 1:
             raise InvalidRequestError("Multiple 'code_challenge_method' in request.")
 
-    def validate_code_verifier(self, grant):
+    def validate_code_verifier(self, grant, result):
         request: OAuth2Request = grant.request
         verifier = request.form.get("code_verifier")
 

--- a/authlib/oauth2/rfc8628/device_code.py
+++ b/authlib/oauth2/rfc8628/device_code.py
@@ -89,7 +89,7 @@ class DeviceCodeGrant(BaseGrant, TokenEndpointMixin):
             &device_code=GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS
             &client_id=1406020730
         """
-        device_code = self.request.data.get("device_code")
+        device_code = self.request.payload.data.get("device_code")
         if not device_code:
             raise InvalidRequestError("Missing 'device_code' in payload")
 

--- a/authlib/oauth2/rfc8628/device_code.py
+++ b/authlib/oauth2/rfc8628/device_code.py
@@ -5,6 +5,7 @@ from ..rfc6749 import TokenEndpointMixin
 from ..rfc6749.errors import AccessDeniedError
 from ..rfc6749.errors import InvalidRequestError
 from ..rfc6749.errors import UnauthorizedClientError
+from ..rfc6749.hooks import hooked
 from .errors import AuthorizationPendingError
 from .errors import ExpiredTokenError
 from .errors import SlowDownError
@@ -111,6 +112,7 @@ class DeviceCodeGrant(BaseGrant, TokenEndpointMixin):
         self.request.client = client
         self.request.credential = credential
 
+    @hooked
     def create_token_response(self):
         """If the access token request is valid and authorized, the
         authorization server issues an access token and optional refresh
@@ -125,7 +127,6 @@ class DeviceCodeGrant(BaseGrant, TokenEndpointMixin):
         )
         log.debug("Issue token %r to %r", token, client)
         self.save_token(token)
-        self.execute_hook("process_token", token=token)
         return 200, token, self.TOKEN_RESPONSE_HEADER
 
     def validate_device_credential(self, credential):

--- a/authlib/oauth2/rfc8628/endpoint.py
+++ b/authlib/oauth2/rfc8628/endpoint.py
@@ -96,7 +96,7 @@ class DeviceAuthorizationEndpoint:
         # https://tools.ietf.org/html/rfc8628#section-3.1
 
         self.authenticate_client(request)
-        self.server.validate_requested_scope(request.scope)
+        self.server.validate_requested_scope(request.payload.scope)
 
         device_code = self.generate_device_code()
         user_code = self.generate_user_code()
@@ -114,7 +114,9 @@ class DeviceAuthorizationEndpoint:
             "interval": self.INTERVAL,
         }
 
-        self.save_device_credential(request.client_id, request.scope, data)
+        self.save_device_credential(
+            request.payload.client_id, request.payload.scope, data
+        )
         return 200, data, default_json_headers
 
     def generate_user_code(self):

--- a/authlib/oauth2/rfc9101/__init__.py
+++ b/authlib/oauth2/rfc9101/__init__.py
@@ -1,0 +1,9 @@
+from .authorization_server import JWTAuthenticationRequest
+from .discovery import AuthorizationServerMetadata
+from .registration import ClientMetadataClaims
+
+__all__ = [
+    "AuthorizationServerMetadata",
+    "JWTAuthenticationRequest",
+    "ClientMetadataClaims",
+]

--- a/authlib/oauth2/rfc9101/authorization_server.py
+++ b/authlib/oauth2/rfc9101/authorization_server.py
@@ -1,0 +1,255 @@
+from authlib.jose import jwt
+from authlib.jose.errors import JoseError
+
+from ..rfc6749 import AuthorizationServer
+from ..rfc6749 import ClientMixin
+from ..rfc6749 import InvalidRequestError
+from ..rfc6749.authenticate_client import _validate_client
+from ..rfc6749.requests import BasicOAuth2Payload
+from ..rfc6749.requests import OAuth2Request
+from .errors import InvalidRequestObjectError
+from .errors import InvalidRequestUriError
+from .errors import RequestNotSupportedError
+from .errors import RequestUriNotSupportedError
+
+
+class JWTAuthenticationRequest:
+    """Authorization server extension implementing the support
+    for JWT secured authentication request, as defined in :rfc:`RFC9101 <9101>`.
+
+    :param support_request: Whether to enable support for the ``request`` parameter.
+    :param support_request_uri: Whether to enable support for the ``request_uri`` parameter.
+
+    This extension is intended to be inherited and registered into the authorization server::
+
+        class JWTAuthenticationRequest(rfc9101.JWTAuthenticationRequest):
+            def resolve_client_public_key(self, client: ClientMixin):
+                return get_jwks_for_client(client)
+
+            def get_request_object(self, request_uri: str):
+                try:
+                    return requests.get(request_uri).text
+                except requests.Exception:
+                    return None
+
+            def get_server_metadata(self):
+                return {
+                    "issuer": ...,
+                    "authorization_endpoint": ...,
+                    "require_signed_request_object": ...,
+                }
+
+            def get_client_require_signed_request_object(self, client: ClientMixin):
+                return client.require_signed_request_object
+
+
+        authorization_server.register_extension(JWTAuthenticationRequest())
+    """
+
+    def __init__(self, support_request: bool = True, support_request_uri: bool = True):
+        self.support_request = support_request
+        self.support_request_uri = support_request_uri
+
+    def __call__(self, authorization_server: AuthorizationServer):
+        authorization_server.register_hook(
+            "before_get_authorization_grant", self.parse_authorization_request
+        )
+
+    def parse_authorization_request(
+        self, authorization_server: AuthorizationServer, request: OAuth2Request
+    ):
+        client = _validate_client(
+            authorization_server.query_client, request.payload.client_id
+        )
+        if not self._shoud_proceed_with_request_object(
+            authorization_server, request, client
+        ):
+            return
+
+        raw_request_object = self._get_raw_request_object(authorization_server, request)
+        request_object = self._decode_request_object(
+            request, client, raw_request_object
+        )
+        payload = BasicOAuth2Payload(request_object)
+        request.payload = payload
+
+    def _shoud_proceed_with_request_object(
+        self,
+        authorization_server: AuthorizationServer,
+        request: OAuth2Request,
+        client: ClientMixin,
+    ) -> bool:
+        if "request" in request.payload.data and "request_uri" in request.payload.data:
+            raise InvalidRequestError(
+                "The 'request' and 'request_uri' parameters are mutually exclusive.",
+                state=request.payload.state,
+            )
+
+        if "request" in request.payload.data:
+            if not self.support_request:
+                raise RequestNotSupportedError(state=request.payload.state)
+            return True
+
+        if "request_uri" in request.payload.data:
+            if not self.support_request_uri:
+                raise RequestUriNotSupportedError(state=request.payload.state)
+            return True
+
+        # When the value of it [require_signed_request_object] as client metadata is true,
+        # then the server MUST reject the authorization request
+        # from the client that does not conform to this specification.
+        if self.get_client_require_signed_request_object(client):
+            raise InvalidRequestError(
+                "Authorization requests for this client must use signed request objects.",
+                state=request.payload.state,
+            )
+
+        # When the value of it [require_signed_request_object] as server metadata is true,
+        # then the server MUST reject the authorization request
+        # from any client that does not conform to this specification.
+        metadata = self.get_server_metadata()
+        if metadata and metadata.get("require_signed_request_object", False):
+            raise InvalidRequestError(
+                "Authorization requests for this server must use signed request objects.",
+                state=request.payload.state,
+            )
+
+        return False
+
+    def _get_raw_request_object(
+        self, authorization_server: AuthorizationServer, request: OAuth2Request
+    ) -> str:
+        if "request_uri" in request.payload.data:
+            raw_request_object = self.get_request_object(
+                request.payload.data["request_uri"]
+            )
+            if not raw_request_object:
+                raise InvalidRequestUriError(state=request.payload.state)
+
+        else:
+            raw_request_object = request.payload.data["request"]
+
+        return raw_request_object
+
+    def _decode_request_object(
+        self, request, client: ClientMixin, raw_request_object: str
+    ):
+        jwks = self.resolve_client_public_key(client)
+
+        try:
+            request_object = jwt.decode(raw_request_object, jwks)
+            request_object.validate()
+
+        except JoseError as error:
+            raise InvalidRequestObjectError(
+                description=error.description or InvalidRequestObjectError.description,
+                state=request.payload.state,
+            ) from error
+
+        # It MUST also reject the request if the Request Object uses an
+        # alg value of none when this server metadata value is true.
+        # If omitted, the default value is false.
+        if (
+            self.get_client_require_signed_request_object(client)
+            and request_object.header["alg"] == "none"
+        ):
+            raise InvalidRequestError(
+                "Authorization requests for this client must use signed request objects.",
+                state=request.payload.state,
+            )
+
+        # It MUST also reject the request if the Request Object uses an
+        # alg value of none. If omitted, the default value is false.
+        metadata = self.get_server_metadata()
+        if (
+            metadata
+            and metadata.get("require_signed_request_object", False)
+            and request_object.header["alg"] == "none"
+        ):
+            raise InvalidRequestError(
+                "Authorization requests for this server must use signed request objects.",
+                state=request.payload.state,
+            )
+
+        # The client ID values in the client_id request parameter and in
+        # the Request Object client_id claim MUST be identical.
+        if request_object["client_id"] != request.payload.client_id:
+            raise InvalidRequestError(
+                "The 'client_id' claim from the request parameters "
+                "and the request object claims don't match.",
+                state=request.payload.state,
+            )
+
+        # The Request Object MAY be sent by value, as described in Section 5.1,
+        # or by reference, as described in Section 5.2. request and
+        # request_uri parameters MUST NOT be included in Request Objects.
+        if "request" in request_object or "request_uri" in request_object:
+            raise InvalidRequestError(
+                "The 'request' and 'request_uri' parameters must not be included in the request object.",
+                state=request.payload.state,
+            )
+
+        return request_object
+
+    def get_request_object(self, request_uri: str):
+        """Download the request object at ``request_uri``.
+
+        This method must be implemented if the ``request_uri`` parameter is supported::
+
+            class JWTAuthenticationRequest(rfc9101.JWTAuthenticationRequest):
+                def get_request_object(self, request_uri: str):
+                    try:
+                        return requests.get(request_uri).text
+                    except requests.Exception:
+                        return None
+        """
+        raise NotImplementedError()
+
+    def resolve_client_public_keys(self, client: ClientMixin):
+        """Resolve the client public key for verifying the JWT signature.
+        A client may have many public keys, in this case, we can retrieve it
+        via ``kid`` value in headers. Developers MUST implement this method::
+
+            class JWTAuthenticationRequest(rfc9101.JWTAuthenticationRequest):
+                def resolve_client_public_key(self, client):
+                    if client.jwks_uri:
+                        return requests.get(client.jwks_uri).json
+
+                    return client.jwks
+        """
+        raise NotImplementedError()
+
+    def get_server_metadata(self) -> dict:
+        """Return server metadata which includes supported grant types,
+        response types and etc.
+
+        When the ``require_signed_request_object`` claim is :data:`True`,
+        all clients require that authorization requests
+        use request objects, and an error will be returned when the authorization
+        request payload is passed in the request body or query string::
+
+            class JWTAuthenticationRequest(rfc9101.JWTAuthenticationRequest):
+                def get_server_metadata(self):
+                    return {
+                        "issuer": ...,
+                        "authorization_endpoint": ...,
+                        "require_signed_request_object": ...,
+                    }
+
+        """
+        return {}  # pragma: no cover
+
+    def get_client_require_signed_request_object(self, client: ClientMixin) -> bool:
+        """Return the 'require_signed_request_object' client metadata.
+
+        When :data:`True`, the client requires that authorization requests
+        use request objects, and an error will be returned when the authorization
+        request payload is passed in the request body or query string::
+
+           class JWTAuthenticationRequest(rfc9101.JWTAuthenticationRequest):
+               def get_client_require_signed_request_object(self, client):
+                   return client.require_signed_request_object
+
+        If not implemented, the value is considered as :data:`False`.
+        """
+        return False  # pragma: no cover

--- a/authlib/oauth2/rfc9101/discovery.py
+++ b/authlib/oauth2/rfc9101/discovery.py
@@ -1,0 +1,9 @@
+from authlib.oidc.discovery.models import _validate_boolean_value
+
+
+class AuthorizationServerMetadata(dict):
+    REGISTRY_KEYS = ["require_signed_request_object"]
+
+    def validate_require_signed_request_object(self):
+        """Indicates where authorization request needs to be protected as Request Object and provided through either request or request_uri parameter."""
+        _validate_boolean_value(self, "require_signed_request_object")

--- a/authlib/oauth2/rfc9101/errors.py
+++ b/authlib/oauth2/rfc9101/errors.py
@@ -1,0 +1,34 @@
+from ..base import OAuth2Error
+
+__all__ = [
+    "InvalidRequestUriError",
+    "InvalidRequestObjectError",
+    "RequestNotSupportedError",
+    "RequestUriNotSupportedError",
+]
+
+
+class InvalidRequestUriError(OAuth2Error):
+    error = "invalid_request_uri"
+    description = "The request_uri in the authorization request returns an error or contains invalid data."
+    status_code = 400
+
+
+class InvalidRequestObjectError(OAuth2Error):
+    error = "invalid_request_object"
+    description = "The request parameter contains an invalid Request Object."
+    status_code = 400
+
+
+class RequestNotSupportedError(OAuth2Error):
+    error = "request_not_supported"
+    description = (
+        "The authorization server does not support the use of the request parameter."
+    )
+    status_code = 400
+
+
+class RequestUriNotSupportedError(OAuth2Error):
+    error = "request_uri_not_supported"
+    description = "The authorization server does not support the use of the request_uri parameter."
+    status_code = 400

--- a/authlib/oauth2/rfc9101/registration.py
+++ b/authlib/oauth2/rfc9101/registration.py
@@ -1,0 +1,44 @@
+from authlib.jose import BaseClaims
+from authlib.jose.errors import InvalidClaimError
+
+
+class ClientMetadataClaims(BaseClaims):
+    """Additional client metadata can be used with :ref:`specs/rfc7591` and :ref:`specs/rfc7592` endpoints.
+
+    This can be used with::
+
+        server.register_endpoint(
+            ClientRegistrationEndpoint(
+                claims_classes=[
+                    rfc7591.ClientMetadataClaims,
+                    rfc9101.ClientMetadataClaims,
+                ]
+            )
+        )
+
+        server.register_endpoint(
+            ClientRegistrationEndpoint(
+                claims_classes=[
+                    rfc7591.ClientMetadataClaims,
+                    rfc9101.ClientMetadataClaims,
+                ]
+            )
+        )
+
+    """
+
+    REGISTERED_CLAIMS = [
+        "require_signed_request_object",
+    ]
+
+    def validate(self):
+        self._validate_essential_claims()
+        self.validate_require_signed_request_object()
+
+    def validate_require_signed_request_object(self):
+        self.setdefault("require_signed_request_object", False)
+
+        if not isinstance(self["require_signed_request_object"], bool):
+            raise InvalidClaimError("require_signed_request_object")
+
+        self._validate_claim_value("require_signed_request_object")

--- a/authlib/oauth2/rfc9207/parameter.py
+++ b/authlib/oauth2/rfc9207/parameter.py
@@ -10,7 +10,7 @@ class IssuerParameter:
         if isinstance(authorization_server, BaseGrant):
             deprecate(
                 "IssueParameter should be used as an authorization server extension with 'authorization_server.register_extension(IssueParameter())'.",
-                version="1.7",
+                version="1.8",
             )
             authorization_server.register_hook(
                 "after_authorization_response",

--- a/authlib/oauth2/rfc9207/parameter.py
+++ b/authlib/oauth2/rfc9207/parameter.py
@@ -1,16 +1,29 @@
 from typing import Optional
 
 from authlib.common.urls import add_params_to_uri
+from authlib.deprecate import deprecate
+from authlib.oauth2.rfc6749.grants import BaseGrant
 
 
 class IssuerParameter:
-    def __call__(self, grant):
-        grant.register_hook(
-            "after_authorization_response",
-            self.add_issuer_parameter,
-        )
+    def __call__(self, authorization_server):
+        if isinstance(authorization_server, BaseGrant):
+            deprecate(
+                "IssueParameter should be used as an authorization server extension with 'authorization_server.register_extension(IssueParameter())'.",
+                version="1.7",
+            )
+            authorization_server.register_hook(
+                "after_authorization_response",
+                self.add_issuer_parameter,
+            )
 
-    def add_issuer_parameter(self, hook_type: str, response):
+        else:
+            authorization_server.register_hook(
+                "after_create_authorization_response",
+                self.add_issuer_parameter,
+            )
+
+    def add_issuer_parameter(self, authorization_server, response):
         if self.get_issuer() and response.location:
             # RFC9207 §2
             # In authorization responses to the client, including error responses,

--- a/authlib/oidc/core/grants/code.py
+++ b/authlib/oidc/core/grants/code.py
@@ -104,7 +104,7 @@ class OpenIDCode(OpenIDToken):
                 return {...}
 
             def exists_nonce(self, nonce, request):
-                return check_if_nonce_in_cache(request.client_id, nonce)
+                return check_if_nonce_in_cache(request.payload.client_id, nonce)
 
             def generate_user_info(self, user, scope):
                 return {...}
@@ -125,7 +125,7 @@ class OpenIDCode(OpenIDToken):
 
             def exists_nonce(self, nonce, request):
                 exists = AuthorizationCode.query.filter_by(
-                    client_id=request.client_id, nonce=nonce
+                    client_id=request.payload.client_id, nonce=nonce
                 ).first()
                 return bool(exists)
 
@@ -140,7 +140,7 @@ class OpenIDCode(OpenIDToken):
 
     def __call__(self, grant):
         grant.register_hook("process_token", self.process_token)
-        if is_openid_scope(grant.request.scope):
+        if is_openid_scope(grant.request.payload.scope):
             grant.register_hook(
                 "after_validate_authorization_request",
                 self.validate_openid_authorization_request,

--- a/authlib/oidc/core/grants/hybrid.py
+++ b/authlib/oidc/core/grants/hybrid.py
@@ -56,8 +56,8 @@ class OpenIDHybridGrant(OpenIDImplicitGrant):
                 redirect_fragment=True,
             )
         self.register_hook(
-            "after_validate_authorization_request",
-            lambda grant: validate_nonce(
+            "after_validate_authorization_request_payload",
+            lambda grant, redirect_uri: validate_nonce(
                 grant.request, grant.exists_nonce, required=True
             ),
         )

--- a/authlib/oidc/core/grants/hybrid.py
+++ b/authlib/oidc/core/grants/hybrid.py
@@ -39,9 +39,9 @@ class OpenIDHybridGrant(OpenIDImplicitGrant):
                 auth_code = AuthorizationCode(
                     code=code,
                     client_id=client.client_id,
-                    redirect_uri=request.redirect_uri,
-                    scope=request.scope,
-                    nonce=request.data.get("nonce"),
+                    redirect_uri=request.payload.redirect_uri,
+                    scope=request.payload.scope,
+                    nonce=request.payload.data.get("nonce"),
                     user_id=request.user.id,
                 )
                 auth_code.save()
@@ -49,10 +49,10 @@ class OpenIDHybridGrant(OpenIDImplicitGrant):
         raise NotImplementedError()
 
     def validate_authorization_request(self):
-        if not is_openid_scope(self.request.scope):
+        if not is_openid_scope(self.request.payload.scope):
             raise InvalidScopeError(
                 "Missing 'openid' scope",
-                redirect_uri=self.request.redirect_uri,
+                redirect_uri=self.request.payload.redirect_uri,
                 redirect_fragment=True,
             )
         self.register_hook(
@@ -72,11 +72,11 @@ class OpenIDHybridGrant(OpenIDImplicitGrant):
         token = self.generate_token(
             grant_type="implicit",
             user=grant_user,
-            scope=self.request.scope,
+            scope=self.request.payload.scope,
             include_refresh_token=False,
         )
 
-        response_types = self.request.response_type.split()
+        response_types = self.request.payload.response_type.split()
         if "token" in response_types:
             log.debug("Grant token %r to %r", token, client)
             self.server.save_token(token, self.request)

--- a/authlib/oidc/core/grants/implicit.py
+++ b/authlib/oidc/core/grants/implicit.py
@@ -4,6 +4,7 @@ from authlib.oauth2.rfc6749 import AccessDeniedError
 from authlib.oauth2.rfc6749 import ImplicitGrant
 from authlib.oauth2.rfc6749 import InvalidScopeError
 from authlib.oauth2.rfc6749 import OAuth2Error
+from authlib.oauth2.rfc6749.hooks import hooked
 
 from .util import create_response_mode_response
 from .util import generate_id_token
@@ -93,9 +94,11 @@ class OpenIDImplicitGrant(ImplicitGrant):
             raise error
         return redirect_uri
 
+    @hooked
     def validate_consent_request(self):
         redirect_uri = self.validate_authorization_request()
         validate_request_prompt(self, redirect_uri, redirect_fragment=True)
+        return redirect_uri
 
     def create_authorization_response(self, redirect_uri, grant_user):
         state = self.request.payload.state

--- a/authlib/oidc/core/grants/util.py
+++ b/authlib/oidc/core/grants/util.py
@@ -19,7 +19,7 @@ def is_openid_scope(scope):
 
 
 def validate_request_prompt(grant, redirect_uri, redirect_fragment=False):
-    prompt = grant.request.data.get("prompt")
+    prompt = grant.request.payload.data.get("prompt")
     end_user = grant.request.user
     if not prompt:
         if not end_user:
@@ -50,7 +50,7 @@ def validate_request_prompt(grant, redirect_uri, redirect_fragment=False):
 
 
 def validate_nonce(request, exists_nonce, required=False):
-    nonce = request.data.get("nonce")
+    nonce = request.payload.data.get("nonce")
     if not nonce:
         if required:
             raise InvalidRequestError("Missing 'nonce' in request.")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Version 1.5.3
 - Support for ``acr`` and ``amr`` claims in ``id_token``. :issue:`734`
 - Support for the ``none`` JWS algorithm.
 - Fix ``response_types`` strict order during dynamic client registration. :issue:`760`
+- Implement :rfc:`RFC9101 The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR) <9101>`. :issue:`723`
 
 Version 1.5.2
 -------------

--- a/docs/django/2/authorization-server.rst
+++ b/docs/django/2/authorization-server.rst
@@ -151,22 +151,22 @@ The ``AuthorizationServer`` has provided built-in methods to handle these endpoi
     # use ``server.create_authorization_response`` to handle authorization endpoint
 
     def authorize(request):
-        if request.method == 'GET':
-            try:
-                grant = server.get_consent_grant(request, end_user=request.user)
-            except OAuth2Error as error:
-                return server.handle_error_response(request, error)
+        try:
+            grant = server.get_consent_grant(request, end_user=request.user)
+        except OAuth2Error as error:
+            return server.handle_error_response(request, error)
 
+        if request.method == 'GET':
             scope = grant.client.get_allowed_scope(grant.request.scope)
             context = dict(grant=grant, client=grant.client, scope=scope, user=request.user)
             return render(request, 'authorize.html', context)
 
         if is_user_confirmed(request):
             # granted by resource owner
-            return server.create_authorization_response(request, grant_user=request.user)
+            return server.create_authorization_response(request, grant=grant, grant_user=request.user)
 
         # denied by resource owner
-        return server.create_authorization_response(request, grant_user=None)
+        return server.create_authorization_response(request, grant=grant, grant_user=None)
 
     # use ``server.create_token_response`` to handle token endpoint
 

--- a/docs/django/2/authorization-server.rst
+++ b/docs/django/2/authorization-server.rst
@@ -157,7 +157,7 @@ The ``AuthorizationServer`` has provided built-in methods to handle these endpoi
             return server.handle_error_response(request, error)
 
         if request.method == 'GET':
-            scope = grant.client.get_allowed_scope(grant.request.scope)
+            scope = grant.client.get_allowed_scope(grant.request.payload.scope)
             context = dict(grant=grant, client=grant.client, scope=scope, user=request.user)
             return render(request, 'authorize.html', context)
 

--- a/docs/django/2/grants.rst
+++ b/docs/django/2/grants.rst
@@ -67,8 +67,8 @@ grant type. Here is how::
                 code=code,
                 client_id=client.client_id,
                 redirect_uri=request.redirect_uri,
-                response_type=request.response_type,
-                scope=request.scope,
+                response_type=request.payload.response_type,
+                scope=request.payload.scope,
                 user=request.user,
             )
             auth_code.save()

--- a/docs/django/2/openid-connect.rst
+++ b/docs/django/2/openid-connect.rst
@@ -112,7 +112,7 @@ First, we need to implement the missing methods for ``OpenIDCode``::
         def exists_nonce(self, nonce, request):
             try:
                 AuthorizationCode.objects.get(
-                    client_id=request.client_id, nonce=nonce
+                    client_id=request.payload.client_id, nonce=nonce
                 )
                 return True
             except AuthorizationCode.DoesNotExist:
@@ -139,13 +139,13 @@ we need to save this value into database. In this case, we have to update our
     class AuthorizationCodeGrant(_AuthorizationCodeGrant):
         def save_authorization_code(self, code, request):
             # openid request MAY have "nonce" parameter
-            nonce = request.data.get('nonce')
+            nonce = request.payload.data.get('nonce')
             client = request.client
             auth_code = AuthorizationCode(
                 code=code,
                 client_id=client.client_id,
                 redirect_uri=request.redirect_uri,
-                scope=request.scope,
+                scope=request.payload.scope,
                 user=request.user,
                 nonce=nonce,
             )
@@ -192,7 +192,7 @@ a scripting language. You need to implement the missing methods of
         def exists_nonce(self, nonce, request):
             try:
                 AuthorizationCode.objects.get(
-                    client_id=request.client_id, nonce=nonce)
+                    client_id=request.payload.client_id, nonce=nonce)
                 )
                 return True
             except AuthorizationCode.DoesNotExist:
@@ -231,13 +231,13 @@ is ``save_authorization_code``. You can implement it like this::
     class OpenIDHybridGrant(grants.OpenIDHybridGrant):
         def save_authorization_code(self, code, request):
             # openid request MAY have "nonce" parameter
-            nonce = request.data.get('nonce')
+            nonce = request.payload.data.get('nonce')
             client = request.client
             auth_code = AuthorizationCode(
                 code=code,
                 client_id=client.client_id,
                 redirect_uri=request.redirect_uri,
-                scope=request.scope,
+                scope=request.payload.scope,
                 user=request.user,
                 nonce=nonce,
             )
@@ -247,7 +247,7 @@ is ``save_authorization_code``. You can implement it like this::
         def exists_nonce(self, nonce, request):
             try:
                 AuthorizationCode.objects.get(
-                    client_id=request.client_id, nonce=nonce)
+                    client_id=request.payload.client_id, nonce=nonce)
                 )
                 return True
             except AuthorizationCode.DoesNotExist:

--- a/docs/flask/2/authorization-server.rst
+++ b/docs/flask/2/authorization-server.rst
@@ -169,15 +169,15 @@ Now define an endpoint for authorization. This endpoint is used by
 
     @app.route('/oauth/authorize', methods=['GET', 'POST'])
     def authorize():
+        try:
+            grant = server.get_consent_grant(end_user=current_user)
+        except OAuth2Error as error:
+            return authorization.handle_error_response(request, error)
+
         # Login is required since we need to know the current resource owner.
         # It can be done with a redirection to the login page, or a login
         # form on this authorization page.
         if request.method == 'GET':
-            try:
-                grant = server.get_consent_grant(end_user=current_user)
-            except OAuth2Error as error:
-                return authorization.handle_error_response(request, error)
-
             scope = grant.client.get_allowed_scope(grant.request.scope)
 
             # You may add a function to extract scope into a list of scopes
@@ -193,10 +193,10 @@ Now define an endpoint for authorization. This endpoint is used by
         confirmed = request.form['confirm']
         if confirmed:
             # granted by resource owner
-            return server.create_authorization_response(grant_user=current_user)
+            return server.create_authorization_response(grant=grant, grant_user=current_user)
 
         # denied by resource owner
-        return server.create_authorization_response(grant_user=None)
+        return server.create_authorization_response(grant=grant, grant_user=None)
 
 This is a simple demo, the real case should be more complex. There is a little
 more complex demo in https://github.com/authlib/example-oauth2-server.

--- a/docs/flask/2/authorization-server.rst
+++ b/docs/flask/2/authorization-server.rst
@@ -178,7 +178,7 @@ Now define an endpoint for authorization. This endpoint is used by
         # It can be done with a redirection to the login page, or a login
         # form on this authorization page.
         if request.method == 'GET':
-            scope = grant.client.get_allowed_scope(grant.request.scope)
+            scope = grant.client.get_allowed_scope(grant.request.payload.scope)
 
             # You may add a function to extract scope into a list of scopes
             # with rich information, e.g.

--- a/docs/flask/2/grants.rst
+++ b/docs/flask/2/grants.rst
@@ -38,7 +38,7 @@ Implement this grant by subclassing :class:`AuthorizationCodeGrant`::
                 code=code,
                 client_id=client.client_id,
                 redirect_uri=request.redirect_uri,
-                scope=request.scope,
+                scope=request.payload.scope,
                 user_id=request.user.id,
             )
             db.session.add(auth_code)

--- a/docs/flask/2/openid-connect.rst
+++ b/docs/flask/2/openid-connect.rst
@@ -103,7 +103,7 @@ First, we need to implement the missing methods for ``OpenIDCode``::
     class OpenIDCode(grants.OpenIDCode):
         def exists_nonce(self, nonce, request):
             exists = AuthorizationCode.query.filter_by(
-                client_id=request.client_id, nonce=nonce
+                client_id=request.payload.client_id, nonce=nonce
             ).first()
             return bool(exists)
 
@@ -128,12 +128,12 @@ update our :ref:`flask_oauth2_code_grant` ``save_authorization_code`` method::
     class AuthorizationCodeGrant(_AuthorizationCodeGrant):
         def save_authorization_code(self, code, request):
             # openid request MAY have "nonce" parameter
-            nonce = request.data.get('nonce')
+            nonce = request.payload.data.get('nonce')
             auth_code = AuthorizationCode(
                 code=code,
                 client_id=request.client.client_id,
                 redirect_uri=request.redirect_uri,
-                scope=request.scope,
+                scope=request.payload.scope,
                 user_id=request.user.id,
                 nonce=nonce,
             )
@@ -183,7 +183,7 @@ a scripting language. You need to implement the missing methods of
     class OpenIDImplicitGrant(grants.OpenIDImplicitGrant):
         def exists_nonce(self, nonce, request):
             exists = AuthorizationCode.query.filter_by(
-                client_id=request.client_id, nonce=nonce
+                client_id=request.payload.client_id, nonce=nonce
             ).first()
             return bool(exists)
 
@@ -221,12 +221,12 @@ is ``save_authorization_code``. You can implement it like this::
 
     class OpenIDHybridGrant(grants.OpenIDHybridGrant):
         def save_authorization_code(self, code, request):
-            nonce = request.data.get('nonce')
+            nonce = request.payload.data.get('nonce')
             item = AuthorizationCode(
                 code=code,
                 client_id=request.client.client_id,
                 redirect_uri=request.redirect_uri,
-                scope=request.scope,
+                scope=request.payload.scope,
                 user_id=request.user.id,
                 nonce=nonce,
             )
@@ -236,7 +236,7 @@ is ``save_authorization_code``. You can implement it like this::
 
         def exists_nonce(self, nonce, request):
             exists = AuthorizationCode.query.filter_by(
-                client_id=request.client_id, nonce=nonce
+                client_id=request.payload.client_id, nonce=nonce
             ).first()
             return bool(exists)
 

--- a/docs/specs/index.rst
+++ b/docs/specs/index.rst
@@ -26,6 +26,7 @@ works.
     rfc8037
     rfc8414
     rfc8628
-    rfc9207
     rfc9068
+    rfc9101
+    rfc9207
     oidc

--- a/docs/specs/rfc7592.rst
+++ b/docs/specs/rfc7592.rst
@@ -35,7 +35,7 @@ Before register the endpoint, developers MUST implement the missing methods::
             return token
 
         def authenticate_client(self, request):
-            client_id = request.data.get('client_id')
+            client_id = request.payload.data.get('client_id')
             return Client.get(client_id=client_id)
 
         def revoke_access_token(self, token, request):

--- a/docs/specs/rfc7636.rst
+++ b/docs/specs/rfc7636.rst
@@ -43,13 +43,13 @@ method::
 
         def save_authorization_code(self, code, request):
             # NOTICE BELOW
-            code_challenge = request.data.get('code_challenge')
-            code_challenge_method = request.data.get('code_challenge_method')
+            code_challenge = request.payload.data.get('code_challenge')
+            code_challenge_method = request.payload.data.get('code_challenge_method')
             auth_code = AuthorizationCode(
                 code=code,
                 client_id=request.client.client_id,
                 redirect_uri=request.redirect_uri,
-                scope=request.scope,
+                scope=request.payload.scope,
                 user_id=request.user.id,
                 code_challenge=code_challenge,
                 code_challenge_method=code_challenge_method,

--- a/docs/specs/rfc9101.rst
+++ b/docs/specs/rfc9101.rst
@@ -1,0 +1,37 @@
+.. _specs/rfc9101:
+
+RFC9101: The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)
+=======================================================================================
+
+This section contains the generic implementation of :rfc:`RFC9101 <9101>`.
+
+This specification describe how to pass the authorization request payload
+in a JWT (called *request object*) instead of directly instead of GET or POST params.
+
+The request object can either be passed directly in a ``request`` parameter,
+or be hosted by the client and be passed by reference with a ``request_uri``
+parameter.
+
+This usage is more secure than passing the request payload directly in the request,
+read the RFC to know all the details.
+
+Request objects are optional, unless it is enforced by clients with the
+``require_signed_request_object`` client metadata, or server-wide with the
+``require_signed_request_object`` server metadata.
+
+API Reference
+-------------
+
+.. module:: authlib.oauth2.rfc9101
+
+.. autoclass:: JWTAuthenticationRequest
+    :member-order: bysource
+    :members:
+
+.. autoclass:: ClientMetadataClaims
+    :member-order: bysource
+    :members:
+
+.. autoclass:: AuthorizationServerMetadata
+    :member-order: bysource
+    :members:

--- a/docs/specs/rfc9207.rst
+++ b/docs/specs/rfc9207.rst
@@ -9,15 +9,15 @@ In summary, RFC9207 advise to return an ``iss`` parameter in authorization code 
 This can simply be done by implementing the :meth:`~authlib.oauth2.rfc9207.parameter.IssuerParameter.get_issuer` method in the :class:`~authlib.oauth2.rfc9207.parameter.IssuerParameter` class,
 and pass it as a :class:`~authlib.oauth2.rfc6749.grants.AuthorizationCodeGrant` extension::
 
-    from authlib.oauth2.rfc9207.parameter import IssuerParameter as _IssuerParameter
+    from authlib.oauth2 import rfc9207
 
-    class IssuerParameter(_IssuerParameter):
+    class IssuerParameter(rfc9207.IssuerParameter):
         def get_issuer(self) -> str:
             return "https://auth.example.org"
 
     ...
 
-    authorization_server.register_grant(AuthorizationCodeGrant, [IssuerParameter()])
+    authorization_server.register_extension(IssuerParameter())
 
 API Reference
 -------------

--- a/tests/django/test_oauth2/models.py
+++ b/tests/django/test_oauth2/models.py
@@ -145,9 +145,9 @@ def generate_authorization_code(client, grant_user, request, **extra):
     item = OAuth2Code(
         code=code,
         client_id=client.client_id,
-        redirect_uri=request.redirect_uri,
-        response_type=request.response_type,
-        scope=request.scope,
+        redirect_uri=request.payload.redirect_uri,
+        response_type=request.payload.response_type,
+        scope=request.payload.scope,
         user=grant_user,
         **extra,
     )

--- a/tests/django/test_oauth2/test_authorization_code_grant.py
+++ b/tests/django/test_oauth2/test_authorization_code_grant.py
@@ -105,14 +105,16 @@ class AuthorizationCodeTest(TestCase):
         self.prepare_data()
         data = {"response_type": "code", "client_id": "client"}
         request = self.factory.post("/authorize", data=data)
-        server.get_consent_grant(request)
+        grant = server.get_consent_grant(request)
 
-        resp = server.create_authorization_response(request)
+        resp = server.create_authorization_response(request, grant=grant)
         assert resp.status_code == 302
         assert "error=access_denied" in resp["Location"]
 
         grant_user = User.objects.get(username="foo")
-        resp = server.create_authorization_response(request, grant_user=grant_user)
+        resp = server.create_authorization_response(
+            request, grant=grant, grant_user=grant_user
+        )
         assert resp.status_code == 302
         assert "code=" in resp["Location"]
 
@@ -171,7 +173,10 @@ class AuthorizationCodeTest(TestCase):
         data = {"response_type": "code", "client_id": "client"}
         request = self.factory.post("/authorize", data=data)
         grant_user = User.objects.get(username="foo")
-        resp = server.create_authorization_response(request, grant_user=grant_user)
+        grant = server.get_consent_grant(request)
+        resp = server.create_authorization_response(
+            request, grant=grant, grant_user=grant_user
+        )
         assert resp.status_code == 302
 
         params = dict(url_decode(urlparse.urlparse(resp["Location"]).query))

--- a/tests/django/test_oauth2/test_authorization_code_grant.py
+++ b/tests/django/test_oauth2/test_authorization_code_grant.py
@@ -22,9 +22,9 @@ class AuthorizationCodeGrant(CodeGrantMixin, grants.AuthorizationCodeGrant):
         auth_code = OAuth2Code(
             code=code,
             client_id=request.client.client_id,
-            redirect_uri=request.redirect_uri,
-            response_type=request.response_type,
-            scope=request.scope,
+            redirect_uri=request.payload.redirect_uri,
+            response_type=request.payload.response_type,
+            scope=request.payload.scope,
             user=request.user,
         )
         auth_code.save()

--- a/tests/django/test_oauth2/test_implicit_grant.py
+++ b/tests/django/test_oauth2/test_implicit_grant.py
@@ -61,15 +61,17 @@ class ImplicitTest(TestCase):
         self.prepare_data()
         data = {"response_type": "token", "client_id": "client"}
         request = self.factory.post("/authorize", data=data)
-        server.get_consent_grant(request)
+        grant = server.get_consent_grant(request)
 
-        resp = server.create_authorization_response(request)
+        resp = server.create_authorization_response(request, grant=grant)
         assert resp.status_code == 302
         params = dict(url_decode(urlparse.urlparse(resp["Location"]).fragment))
         assert params["error"] == "access_denied"
 
         grant_user = User.objects.get(username="foo")
-        resp = server.create_authorization_response(request, grant_user=grant_user)
+        resp = server.create_authorization_response(
+            request, grant=grant, grant_user=grant_user
+        )
         assert resp.status_code == 302
         params = dict(url_decode(urlparse.urlparse(resp["Location"]).fragment))
         assert "access_token" in params

--- a/tests/flask/test_oauth2/models.py
+++ b/tests/flask/test_oauth2/models.py
@@ -68,12 +68,12 @@ def save_authorization_code(code, request):
     auth_code = AuthorizationCode(
         code=code,
         client_id=client.client_id,
-        redirect_uri=request.redirect_uri,
-        scope=request.scope,
-        nonce=request.data.get("nonce"),
+        redirect_uri=request.payload.redirect_uri,
+        scope=request.payload.scope,
+        nonce=request.payload.data.get("nonce"),
         user_id=request.user.id,
-        code_challenge=request.data.get("code_challenge"),
-        code_challenge_method=request.data.get("code_challenge_method"),
+        code_challenge=request.payload.data.get("code_challenge"),
+        code_challenge_method=request.payload.data.get("code_challenge_method"),
         acr="urn:mace:incommon:iap:silver",
         amr="pwd otp",
     )
@@ -82,8 +82,8 @@ def save_authorization_code(code, request):
     return auth_code
 
 
-def exists_nonce(nonce, req):
+def exists_nonce(nonce, request):
     exists = AuthorizationCode.query.filter_by(
-        client_id=req.client_id, nonce=nonce
+        client_id=request.payload.client_id, nonce=nonce
     ).first()
     return bool(exists)

--- a/tests/flask/test_oauth2/oauth2_server.py
+++ b/tests/flask/test_oauth2/oauth2_server.py
@@ -44,14 +44,15 @@ def create_authorization_server(app, lazy=False):
         else:
             end_user = None
 
-        if request.method == "GET":
-            try:
-                grant = server.get_consent_grant(end_user=end_user)
-                return grant.prompt or "ok"
-            except OAuth2Error as error:
-                return server.handle_error_response(request, error)
+        try:
+            grant = server.get_consent_grant(end_user=end_user)
+        except OAuth2Error as error:
+            return server.handle_error_response(request, error)
 
-        return server.create_authorization_response(grant_user=end_user)
+        if request.method == "GET":
+            return grant.prompt or "ok"
+
+        return server.create_authorization_response(grant=grant, grant_user=end_user)
 
     @app.route("/oauth/token", methods=["GET", "POST"])
     def issue_token():

--- a/tests/flask/test_oauth2/test_authorization_code_iss_parameter.py
+++ b/tests/flask/test_oauth2/test_authorization_code_iss_parameter.py
@@ -36,8 +36,9 @@ class RFC9207AuthorizationCodeTest(TestCase):
         rfc9207=True,
     ):
         server = create_authorization_server(self.app, self.LAZY_INIT)
-        extensions = [IssuerParameter()] if rfc9207 else []
-        server.register_grant(AuthorizationCodeGrant, extensions=extensions)
+        if rfc9207:
+            server.register_extension(IssuerParameter())
+        server.register_grant(AuthorizationCodeGrant)
         self.server = server
 
         user = User(username="foo")

--- a/tests/flask/test_oauth2/test_jwt_authorization_request.py
+++ b/tests/flask/test_oauth2/test_jwt_authorization_request.py
@@ -1,0 +1,442 @@
+import json
+
+from authlib.common.urls import add_params_to_uri
+from authlib.jose import jwt
+from authlib.oauth2 import rfc7591
+from authlib.oauth2 import rfc9101
+from authlib.oauth2.rfc6749.grants import (
+    AuthorizationCodeGrant as _AuthorizationCodeGrant,
+)
+from tests.util import read_file_path
+
+from .models import Client
+from .models import CodeGrantMixin
+from .models import User
+from .models import db
+from .models import save_authorization_code
+from .oauth2_server import TestCase
+from .oauth2_server import create_authorization_server
+
+
+class AuthorizationCodeGrant(CodeGrantMixin, _AuthorizationCodeGrant):
+    TOKEN_ENDPOINT_AUTH_METHODS = ["client_secret_basic", "client_secret_post", "none"]
+
+    def save_authorization_code(self, code, request):
+        return save_authorization_code(code, request)
+
+
+class AuthorizationCodeTest(TestCase):
+    def register_grant(self, server):
+        server.register_grant(AuthorizationCodeGrant)
+
+    def prepare_data(
+        self,
+        request_object=None,
+        support_request=True,
+        support_request_uri=True,
+        metadata=None,
+        client_require_signed_request_object=False,
+    ):
+        class JWTAuthenticationRequest(rfc9101.JWTAuthenticationRequest):
+            def resolve_client_public_key(self, client):
+                return read_file_path("jwk_public.json")
+
+            def get_request_object(self, request_uri: str):
+                return request_object
+
+            def get_server_metadata(self):
+                return metadata
+
+            def get_client_require_signed_request_object(self, client):
+                return client.client_metadata.get(
+                    "require_signed_request_object", False
+                )
+
+        class ClientRegistrationEndpoint(rfc7591.ClientRegistrationEndpoint):
+            software_statement_alg_values_supported = ["RS256"]
+
+            def authenticate_token(self, request):
+                auth_header = request.headers.get("Authorization")
+                request.user_id = 1
+                return auth_header
+
+            def resolve_public_key(self, request):
+                return read_file_path("rsa_public.pem")
+
+            def save_client(self, client_info, client_metadata, request):
+                client = Client(user_id=request.user_id, **client_info)
+                client.set_client_metadata(client_metadata)
+                db.session.add(client)
+                db.session.commit()
+                return client
+
+            def get_server_metadata(self):
+                return metadata
+
+        server = create_authorization_server(self.app)
+        server.register_extension(
+            JWTAuthenticationRequest(
+                support_request=support_request, support_request_uri=support_request_uri
+            )
+        )
+        self.register_grant(server)
+        server.register_endpoint(
+            ClientRegistrationEndpoint(
+                claims_classes=[
+                    rfc7591.ClientMetadataClaims,
+                    rfc9101.ClientMetadataClaims,
+                ]
+            )
+        )
+        self.server = server
+        user = User(username="foo")
+        db.session.add(user)
+        db.session.commit()
+
+        @self.app.route("/create_client", methods=["POST"])
+        def create_client():
+            return server.create_endpoint_response("client_registration")
+
+        client = Client(
+            user_id=user.id,
+            client_id="code-client",
+            client_secret="code-secret",
+        )
+        client.set_client_metadata(
+            {
+                "redirect_uris": ["https://a.b"],
+                "scope": "profile address",
+                "token_endpoint_auth_method": "client_secret_basic",
+                "response_types": ["code"],
+                "grant_types": ["authorization_code"],
+                "jwks": read_file_path("jwks_public.json"),
+                "require_signed_request_object": client_require_signed_request_object,
+            }
+        )
+        self.authorize_url = "/oauth/authorize"
+        db.session.add(client)
+        db.session.commit()
+
+    def test_request_parameter_get(self):
+        """Pass the authentication payload in a JWT in the request query parameter."""
+
+        self.prepare_data()
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        url = add_params_to_uri(
+            self.authorize_url, {"client_id": "code-client", "request": request_obj}
+        )
+        rv = self.client.get(url)
+        assert rv.data == b"ok"
+
+    def test_request_uri_parameter_get(self):
+        """Pass the authentication payload in a JWT in the request_uri query parameter."""
+
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        self.prepare_data(request_object=request_obj)
+
+        url = add_params_to_uri(
+            self.authorize_url,
+            {
+                "client_id": "code-client",
+                "request_uri": "https://client.test/request_object",
+            },
+        )
+        rv = self.client.get(url)
+        assert rv.data == b"ok"
+
+    def test_request_and_request_uri_parameters(self):
+        """Passing both requests and request_uri parameters should return an error."""
+
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        self.prepare_data(request_object=request_obj)
+
+        url = add_params_to_uri(
+            self.authorize_url,
+            {
+                "client_id": "code-client",
+                "request": request_obj,
+                "request_uri": "https://client.test/request_object",
+            },
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request"
+        assert (
+            params["error_description"]
+            == "The 'request' and 'request_uri' parameters are mutually exclusive."
+        )
+
+    def test_neither_request_nor_request_uri_parameter(self):
+        """Passing parameters in the query string and not in a request object should still work."""
+
+        self.prepare_data()
+        url = add_params_to_uri(
+            self.authorize_url, {"response_type": "code", "client_id": "code-client"}
+        )
+        rv = self.client.get(url)
+        assert rv.data == b"ok"
+
+    def test_server_require_request_object(self):
+        """When server metadata 'require_signed_request_object' is true, request objects must be used."""
+
+        self.prepare_data(metadata={"require_signed_request_object": True})
+        url = add_params_to_uri(
+            self.authorize_url, {"response_type": "code", "client_id": "code-client"}
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request"
+        assert (
+            params["error_description"]
+            == "Authorization requests for this server must use signed request objects."
+        )
+
+    def test_server_require_request_object_alg_none(self):
+        """When server metadata 'require_signed_request_object' is true, the JWT alg cannot be none."""
+
+        self.prepare_data(metadata={"require_signed_request_object": True})
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode(
+            {"alg": "none"}, payload, read_file_path("jwk_private.json")
+        )
+        url = add_params_to_uri(
+            self.authorize_url, {"client_id": "code-client", "request": request_obj}
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request"
+        assert (
+            params["error_description"]
+            == "Authorization requests for this server must use signed request objects."
+        )
+
+    def test_client_require_signed_request_object(self):
+        """When client metadata 'require_signed_request_object' is true, request objects must be used."""
+
+        self.prepare_data(client_require_signed_request_object=True)
+        url = add_params_to_uri(
+            self.authorize_url, {"response_type": "code", "client_id": "code-client"}
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request"
+        assert (
+            params["error_description"]
+            == "Authorization requests for this client must use signed request objects."
+        )
+
+    def test_client_require_signed_request_object_alg_none(self):
+        """When client metadata 'require_signed_request_object' is true, the JWT alg cannot be none."""
+
+        self.prepare_data(client_require_signed_request_object=True)
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode({"alg": "none"}, payload, "")
+        url = add_params_to_uri(
+            self.authorize_url, {"client_id": "code-client", "request": request_obj}
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request"
+        assert (
+            params["error_description"]
+            == "Authorization requests for this client must use signed request objects."
+        )
+
+    def test_unsupported_request_parameter(self):
+        """Passing the request parameter when unsupported should raise a 'request_not_supported' error."""
+
+        self.prepare_data(support_request=False)
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        url = add_params_to_uri(
+            self.authorize_url, {"client_id": "code-client", "request": request_obj}
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "request_not_supported"
+        assert (
+            params["error_description"]
+            == "The authorization server does not support the use of the request parameter."
+        )
+
+    def test_unsupported_request_uri_parameter(self):
+        """Passing the request parameter when unsupported should raise a 'request_uri_not_supported' error."""
+
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        self.prepare_data(request_object=request_obj, support_request_uri=False)
+
+        url = add_params_to_uri(
+            self.authorize_url,
+            {
+                "client_id": "code-client",
+                "request_uri": "https://client.test/request_object",
+            },
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "request_uri_not_supported"
+        assert (
+            params["error_description"]
+            == "The authorization server does not support the use of the request_uri parameter."
+        )
+
+    def test_invalid_request_uri_parameter(self):
+        """Invalid request_uri (or unreachable etc.) should raise a invalid_request_uri error."""
+
+        self.prepare_data()
+        url = add_params_to_uri(
+            self.authorize_url,
+            {
+                "client_id": "code-client",
+                "request_uri": "https://client.test/request_object",
+            },
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request_uri"
+        assert (
+            params["error_description"]
+            == "The request_uri in the authorization request returns an error or contains invalid data."
+        )
+
+    def test_invalid_request_object(self):
+        """Invalid request object should raise a invalid_request_object error."""
+
+        self.prepare_data()
+        url = add_params_to_uri(
+            self.authorize_url,
+            {
+                "client_id": "code-client",
+                "request": "invalid",
+            },
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request_object"
+        assert (
+            params["error_description"]
+            == "The request parameter contains an invalid Request Object."
+        )
+
+    def test_missing_client_id(self):
+        """The client_id parameter is mandatory."""
+
+        self.prepare_data()
+        payload = {"response_type": "code", "client_id": "code-client"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        url = add_params_to_uri(self.authorize_url, {"request": request_obj})
+
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_client"
+        assert params["error_description"] == "Missing 'client_id' parameter."
+
+    def test_invalid_client_id(self):
+        """The client_id parameter is mandatory."""
+
+        self.prepare_data()
+        payload = {"response_type": "code", "client_id": "invalid"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        url = add_params_to_uri(
+            self.authorize_url, {"client_id": "invalid", "request": request_obj}
+        )
+
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_client"
+        assert (
+            params["error_description"] == "The client does not exist on this server."
+        )
+
+    def test_different_client_id(self):
+        """The client_id parameter should be the same in the request payload and the request object."""
+
+        self.prepare_data()
+        payload = {"response_type": "code", "client_id": "other-code-client"}
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        url = add_params_to_uri(
+            self.authorize_url, {"client_id": "code-client", "request": request_obj}
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request"
+        assert (
+            params["error_description"]
+            == "The 'client_id' claim from the request parameters and the request object claims don't match."
+        )
+
+    def test_request_param_in_request_object(self):
+        """The request and request_uri parameters should not be present in the request object."""
+
+        self.prepare_data()
+        payload = {
+            "response_type": "code",
+            "client_id": "code-client",
+            "request_uri": "https://client.test/request_object",
+        }
+        request_obj = jwt.encode(
+            {"alg": "RS256"}, payload, read_file_path("jwk_private.json")
+        )
+        url = add_params_to_uri(
+            self.authorize_url, {"client_id": "code-client", "request": request_obj}
+        )
+        rv = self.client.get(url)
+        params = json.loads(rv.data)
+        assert params["error"] == "invalid_request"
+        assert (
+            params["error_description"]
+            == "The 'request' and 'request_uri' parameters must not be included in the request object."
+        )
+
+    def test_registration(self):
+        """The 'require_signed_request_object' parameter should be available for client registration."""
+        self.prepare_data()
+        headers = {"Authorization": "bearer abc"}
+
+        # Default case
+        body = {
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["client_name"] == "Authlib"
+        assert resp["require_signed_request_object"] is False
+
+        # Nominal case
+        body = {
+            "require_signed_request_object": True,
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["client_name"] == "Authlib"
+        assert resp["require_signed_request_object"] is True
+
+        # Error case
+        body = {
+            "require_signed_request_object": "invalid",
+            "client_name": "Authlib",
+        }
+        rv = self.client.post("/create_client", json=body, headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["error"] == "invalid_client_metadata"


### PR DESCRIPTION
This pull request brings a few refactoring and the implementation for [RFC 9101
The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR)](https://www.rfc-editor.org/rfc/rfc9101.html).

To summarize, RFC9101 is about passing the authorization request payload in a JWT, called request object, instead of passing it in the request body or query string. The request object is passed in a `request` parameter or hosted at the client and the URI to the request object is passed in a `request_uri` parameter.

To achieve this I had to perform some refactoring, and deprecate some usage with planned removal for Authlib 1.7 (so we can release 1.6 including this PR).

- The hook mechanism has been reworked, and the `execute_hook` method is replaced by a `hooked` decorator. This helps catching a method result every time when several `return` calls are in the method. There is no deprecation for hooks as I considered it is Authlib private API.
- A `AuthorizationServer` extension mechanism is introduced, and the RFC9207 `IssueParameter` is now an authorization server extension instead of a grant extension. Using `IssueParameter` as a grant extension is tolerated until 1.7.
- The `create_authorization_response` takes a `grant` parameter. This is to avoid calling `get_consent_grant` twice, which can be costly when a network request is performed to reach the `request_uri` endpoint. The parameter is optional at the moment but will become mandatory with 1.7.
- The `OAuth2Request` has been split in another `OAuth2Payload` class. This help separate the request object and the request payload, so the rfc9101 extension can overwrite the request payload with the request object content. Properties like `request.data` are deprecated in favor of `request.payload.data` and will be removed in 1.7.

Fixes #723