### PR TITLE
OIDC userinfo endpoint support

### DIFF
--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -221,3 +221,19 @@ class TokenMixin:
         :return: boolean
         """
         raise NotImplementedError()
+
+    def get_user(self):
+        """A method to get the user object associated with this token::
+
+        def get_user(self):
+            return User.get(self.user_id)
+        """
+        raise NotImplementedError()
+
+    def get_client(self) -> ClientMixin:
+        """A method to get the client object associated with this token::
+
+        def get_client(self):
+            return Client.get(self.client_id)
+        """
+        raise NotImplementedError()

--- a/authlib/oidc/core/__init__.py
+++ b/authlib/oidc/core/__init__.py
@@ -17,6 +17,7 @@ from .grants import OpenIDHybridGrant
 from .grants import OpenIDImplicitGrant
 from .grants import OpenIDToken
 from .models import AuthorizationCodeMixin
+from .userinfo import UserInfoEndpoint
 
 __all__ = [
     "AuthorizationCodeMixin",
@@ -25,6 +26,7 @@ __all__ = [
     "ImplicitIDToken",
     "HybridIDToken",
     "UserInfo",
+    "UserInfoEndpoint",
     "get_claim_cls_by_response_type",
     "OpenIDToken",
     "OpenIDCode",

--- a/authlib/oidc/core/claims.py
+++ b/authlib/oidc/core/claims.py
@@ -5,6 +5,7 @@ from authlib.common.encoding import to_bytes
 from authlib.jose import JWTClaims
 from authlib.jose.errors import InvalidClaimError
 from authlib.jose.errors import MissingClaimError
+from authlib.oauth2.rfc6749.util import scope_to_list
 
 from .util import create_half_hash
 
@@ -247,6 +248,42 @@ class UserInfo(dict):
         "address",
         "updated_at",
     ]
+
+    SCOPES_CLAIMS_MAPPING = {
+        "openid": ["sub"],
+        "profile": [
+            "name",
+            "family_name",
+            "given_name",
+            "middle_name",
+            "nickname",
+            "preferred_username",
+            "profile",
+            "picture",
+            "website",
+            "gender",
+            "birthdate",
+            "zoneinfo",
+            "locale",
+            "updated_at",
+        ],
+        "email": ["email", "email_verified"],
+        "address": ["address"],
+        "phone": ["phone_number", "phone_number_verified"],
+    }
+
+    def filter(self, scope: str):
+        """Return a new UserInfo object containing only the claims matching the scope passed in parameter."""
+        scope = scope_to_list(scope)
+        filtered_claims = [
+            claim
+            for scope_part in scope
+            for claim in self.SCOPES_CLAIMS_MAPPING.get(scope_part, [])
+        ]
+        filtered_items = {
+            key: val for key, val in self.items() if key in filtered_claims
+        }
+        return UserInfo(filtered_items)
 
     def __getattr__(self, key):
         try:

--- a/authlib/oidc/core/userinfo.py
+++ b/authlib/oidc/core/userinfo.py
@@ -1,0 +1,120 @@
+from typing import Optional
+
+from authlib.consts import default_json_headers
+from authlib.jose import jwt
+from authlib.oauth2.rfc6749.authorization_server import AuthorizationServer
+from authlib.oauth2.rfc6749.authorization_server import OAuth2Request
+from authlib.oauth2.rfc6749.resource_protector import ResourceProtector
+
+from .claims import UserInfo
+
+
+class UserInfoEndpoint:
+    """OpenID Connect Core UserInfo Endpoint.
+
+    This endpoint returns information about a given user, as a JSON payload or as a JWT.
+    It must be subclassed and a few methods needs to be manually implemented::
+
+        class UserInfoEndpoint(oidc.core.UserInfoEndpoint):
+            def get_issuer(self):
+                return "https://auth.example"
+
+            def generate_user_info(self, user, scope):
+                return UserInfo(
+                    sub=user.id,
+                    name=user.name,
+                    ...
+                ).filter(scope)
+
+            def resolve_private_key(self):
+                return server_private_jwk_set()
+
+    It is also needed to pass a :class:`~authlib.oauth2.rfc6749.ResourceProtector` instance
+    with a registered :class:`~authlib.oauth2.rfc6749.TokenValidator` at initialization,
+    so the access to the endpoint can be restricter to valid token bearers::
+
+        resource_protector = ResourceProtector()
+        resource_protector.register_token_validator(BearerTokenValidator())
+        server.register_endpoint(
+            UserInfoEndpoint(resource_protector=resource_protector)
+        )
+
+    And then you can plug the endpoint to your application::
+
+        @app.route("/oauth/userinfo", methods=["GET", "POST"])
+        def userinfo():
+            return server.create_endpoint_response("userinfo")
+
+    """
+
+    ENDPOINT_NAME = "userinfo"
+
+    def __init__(
+        self,
+        server: Optional[AuthorizationServer] = None,
+        resource_protector: Optional[ResourceProtector] = None,
+    ):
+        self.server = server
+        self.resource_protector = resource_protector
+
+    def create_endpoint_request(self, request: OAuth2Request):
+        return self.server.create_oauth2_request(request)
+
+    def __call__(self, request: OAuth2Request):
+        token = self.resource_protector.acquire_token("openid")
+        client = token.get_client()
+        user = token.get_user()
+        user_info = self.generate_user_info(user, token.scope)
+
+        if alg := client.client_metadata.get("userinfo_signed_response_alg"):
+            # If signed, the UserInfo Response MUST contain the Claims iss
+            # (issuer) and aud (audience) as members. The iss value MUST be
+            # the OP's Issuer Identifier URL. The aud value MUST be or
+            # include the RP's Client ID value.
+            user_info["iss"] = self.get_issuer()
+            user_info["aud"] = client.client_id
+
+            data = jwt.encode({"alg": alg}, user_info, self.resolve_private_key())
+            return 200, data, [("Content-Type", "application/jwt")]
+
+        return 200, user_info, default_json_headers
+
+    def generate_user_info(self, user, scope: str) -> UserInfo:
+        """
+        Generate a :class:`~authlib.oidc.core.UserInfo` object for an user::
+
+            def generate_user_info(self, user, scope: str) -> UserInfo:
+                return UserInfo(
+                    given_name=user.given_name,
+                    family_name=user.last_name,
+                    email=user.email,
+                    ...
+                ).filter(scope)
+
+        This method must be implemented by developers.
+        """
+        raise NotImplementedError()
+
+    def get_issuer(self) -> str:
+        """The OP's Issuer Identifier URL.
+
+        The value is used to fill the ``iss`` claim that is mandatory in signed userinfo::
+
+            def get_issuer(self) -> str:
+                return "https://auth.example"
+
+        This method must be implemented by developers to support JWT userinfo.
+        """
+        raise NotImplementedError()
+
+    def resolve_private_key(self):
+        """Return the server JSON Web Key Set.
+
+        This is used to sign userinfo payloads::
+
+            def resolve_private_key(self):
+                return server_private_jwk_set()
+
+        This method must be implemented by developers to support JWT userinfo signing.
+        """
+        return None  # pragma: no cover

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ Version 1.5.3
 - Support for ``acr`` and ``amr`` claims in ``id_token``. :issue:`734`
 - Support for the ``none`` JWS algorithm.
 - Fix ``response_types`` strict order during dynamic client registration. :issue:`760`
+- OIDC :class:`UserInfo endpoint <authlib.oidc.core.userinfo.UserInfoEndpoint>` support. :issue:`459`
+
 
 Version 1.5.2
 -------------

--- a/docs/django/2/openid-connect.rst
+++ b/docs/django/2/openid-connect.rst
@@ -127,10 +127,11 @@ First, we need to implement the missing methods for ``OpenIDCode``::
             }
 
         def generate_user_info(self, user, scope):
-            user_info = UserInfo(sub=str(user.pk), name=user.name)
-            if 'email' in scope:
-                user_info['email'] = user.email
-            return user_info
+            return UserInfo(
+                sub=str(user.pk),
+                name=user.name,
+                email=user.email,
+            ).filter(scope)
 
 Second, since there is one more ``nonce`` value in ``AuthorizationCode`` data,
 we need to save this value into database. In this case, we have to update our
@@ -207,10 +208,11 @@ a scripting language. You need to implement the missing methods of
             }
 
         def generate_user_info(self, user, scope):
-            user_info = UserInfo(sub=user.id, name=user.name)
-            if 'email' in scope:
-                user_info['email'] = user.email
-            return user_info
+            return UserInfo(
+                sub=str(user.pk),
+                name=user.name,
+                email=user.email,
+            ).filter(scope)
 
     server.register_grant(OpenIDImplicitGrant)
 
@@ -262,10 +264,11 @@ is ``save_authorization_code``. You can implement it like this::
             }
 
         def generate_user_info(self, user, scope):
-            user_info = UserInfo(sub=user.id, name=user.name)
-            if 'email' in scope:
-                user_info['email'] = user.email
-            return user_info
+            return UserInfo(
+                sub=str(user.pk),
+                name=user.name,
+                email=user.email,
+            ).filter(scope)
 
     # register it to grant endpoint
     server.register_grant(OpenIDHybridGrant)

--- a/docs/flask/2/openid-connect.rst
+++ b/docs/flask/2/openid-connect.rst
@@ -116,10 +116,11 @@ First, we need to implement the missing methods for ``OpenIDCode``::
             }
 
         def generate_user_info(self, user, scope):
-            user_info = UserInfo(sub=user.id, name=user.name)
-            if 'email' in scope:
-                user_info['email'] = user.email
-            return user_info
+            return UserInfo(
+                sub=user.id,
+                name=user.name,
+                email=user.email,
+            ).filter(scope)
 
 Second, since there is one more ``nonce`` value in the ``AuthorizationCode``
 data, we need to save this value into the database. In this case, we have to
@@ -196,10 +197,11 @@ a scripting language. You need to implement the missing methods of
             }
 
         def generate_user_info(self, user, scope):
-            user_info = UserInfo(sub=user.id, name=user.name)
-            if 'email' in scope:
-                user_info['email'] = user.email
-            return user_info
+            return UserInfo(
+                sub=user.id,
+                name=user.name,
+                email=user.email,
+            ).filter(scope)
 
     server.register_grant(OpenIDImplicitGrant)
 
@@ -249,10 +251,11 @@ is ``save_authorization_code``. You can implement it like this::
             }
 
         def generate_user_info(self, user, scope):
-            user_info = UserInfo(sub=user.id, name=user.name)
-            if 'email' in scope:
-                user_info['email'] = user.email
-            return user_info
+            return UserInfo(
+                sub=user.id,
+                name=user.name,
+                email=user.email,
+            ).filter(scope)
 
     # register it to grant endpoint
     server.register_grant(OpenIDHybridGrant)

--- a/docs/specs/oidc.rst
+++ b/docs/specs/oidc.rst
@@ -31,10 +31,19 @@ OpenID Grants
     :show-inheritance:
     :members:
 
+OpenID Endpoints
+----------------
+
+.. module:: authlib.oidc.core
+
+.. autoclass:: UserInfoEndpoint
+    :show-inheritance:
+    :members:
+
 OpenID Claims
 -------------
 
-.. module:: authlib.oidc.core
+.. module:: authlib.oidc.core.claims
 
 .. autoclass:: IDToken
     :show-inheritance:

--- a/tests/flask/test_oauth2/models.py
+++ b/tests/flask/test_oauth2/models.py
@@ -18,8 +18,36 @@ class User(db.Model):
     def check_password(self, password):
         return password != "wrong"
 
-    def generate_user_info(self, scopes):
-        profile = {"sub": str(self.id), "name": self.username}
+    def generate_user_info(self, scopes=None):
+        profile = {
+            "sub": str(self.id),
+            "name": self.username,
+            "given_name": "Jane",
+            "family_name": "Doe",
+            "middle_name": "Middle",
+            "nickname": "Jany",
+            "preferred_username": "j.doe",
+            "profile": "https://example.com/janedoe",
+            "picture": "https://example.com/janedoe/me.jpg",
+            "website": "https://example.com",
+            "email": "janedoe@example.com",
+            "email_verified": True,
+            "gender": "female",
+            "birthdate": "2000-12-01",
+            "zoneinfo": "Europe/Paris",
+            "locale": "fr-FR",
+            "phone_number": "+1 (425) 555-1212",
+            "phone_number_verified": False,
+            "address": {
+                "formatted": "742 Evergreen Terrace, Springfield",
+                "street_address": "742 Evergreen Terrace",
+                "locality": "Springfield",
+                "region": "Unknown",
+                "postal_code": "1245",
+                "country": "USA",
+            },
+            "updated_at": 1745315119,
+        }
         return UserInfo(profile)
 
 
@@ -45,6 +73,12 @@ class Token(db.Model, OAuth2TokenMixin):
 
     def is_refresh_token_active(self):
         return not self.refresh_token_revoked_at
+
+    def get_client(self):
+        return db.session.query(Client).filter_by(client_id=self.client_id).one()
+
+    def get_user(self):
+        return self.user
 
 
 class CodeGrantMixin:

--- a/tests/flask/test_oauth2/test_userinfo.py
+++ b/tests/flask/test_oauth2/test_userinfo.py
@@ -1,0 +1,285 @@
+from flask import json
+
+import authlib.oidc.core as oidc_core
+from authlib.integrations.flask_oauth2 import ResourceProtector
+from authlib.integrations.sqla_oauth2 import create_bearer_token_validator
+from authlib.jose import jwt
+from tests.util import read_file_path
+
+from .models import Client
+from .models import Token
+from .models import User
+from .models import db
+from .oauth2_server import TestCase
+from .oauth2_server import create_authorization_server
+
+
+class UserInfoEndpointTest(TestCase):
+    def prepare_data(
+        self,
+        token_scope="openid",
+        userinfo_signed_response_alg=None,
+        userinfo_encrypted_response_alg=None,
+        userinfo_encrypted_response_enc=None,
+    ):
+        app = self.app
+        server = create_authorization_server(app)
+
+        class UserInfoEndpoint(oidc_core.UserInfoEndpoint):
+            def get_issuer(self) -> str:
+                return "https://auth.example"
+
+            def generate_user_info(self, user, scope):
+                return user.generate_user_info().filter(scope)
+
+            def resolve_private_key(self):
+                return read_file_path("jwks_private.json")
+
+        BearerTokenValidator = create_bearer_token_validator(db.session, Token)
+        resource_protector = ResourceProtector()
+        resource_protector.register_token_validator(BearerTokenValidator())
+        server.register_endpoint(
+            UserInfoEndpoint(resource_protector=resource_protector)
+        )
+
+        @app.route("/oauth/userinfo", methods=["GET", "POST"])
+        def userinfo():
+            return server.create_endpoint_response("userinfo")
+
+        user = User(username="foo")
+        db.session.add(user)
+        db.session.commit()
+        client = Client(
+            user_id=user.id,
+            client_id="userinfo-client",
+            client_secret="userinfo-secret",
+        )
+        client.set_client_metadata(
+            {
+                "scope": "profile",
+                "redirect_uris": ["http://localhost/authorized"],
+                "userinfo_signed_response_alg": userinfo_signed_response_alg,
+                "userinfo_encrypted_response_alg": userinfo_encrypted_response_alg,
+                "userinfo_encrypted_response_enc": userinfo_encrypted_response_enc,
+            }
+        )
+        db.session.add(client)
+        db.session.commit()
+
+        token = Token(
+            user_id=1,
+            client_id="userinfo-client",
+            token_type="bearer",
+            access_token="access-token",
+            refresh_token="r1",
+            scope=token_scope,
+            expires_in=3600,
+        )
+        db.session.add(token)
+        db.session.commit()
+
+    def test_get(self):
+        """The UserInfo Endpoint MUST support the use of the HTTP GET and HTTP POST methods defined in RFC 7231 [RFC7231].
+        The UserInfo Endpoint MUST accept Access Tokens as OAuth 2.0 Bearer Token Usage [RFC6750]."""
+
+        self.prepare_data("openid profile email address phone")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        assert rv.headers["Content-Type"] == "application/json"
+
+        resp = json.loads(rv.data)
+        assert resp == {
+            "sub": "1",
+            "address": {
+                "country": "USA",
+                "formatted": "742 Evergreen Terrace, Springfield",
+                "locality": "Springfield",
+                "postal_code": "1245",
+                "region": "Unknown",
+                "street_address": "742 Evergreen Terrace",
+            },
+            "birthdate": "2000-12-01",
+            "email": "janedoe@example.com",
+            "email_verified": True,
+            "family_name": "Doe",
+            "gender": "female",
+            "given_name": "Jane",
+            "locale": "fr-FR",
+            "middle_name": "Middle",
+            "name": "foo",
+            "nickname": "Jany",
+            "phone_number": "+1 (425) 555-1212",
+            "phone_number_verified": False,
+            "picture": "https://example.com/janedoe/me.jpg",
+            "preferred_username": "j.doe",
+            "profile": "https://example.com/janedoe",
+            "updated_at": 1745315119,
+            "website": "https://example.com",
+            "zoneinfo": "Europe/Paris",
+        }
+
+    def test_post(self):
+        """The UserInfo Endpoint MUST support the use of the HTTP GET and HTTP POST methods defined in RFC 7231 [RFC7231].
+        The UserInfo Endpoint MUST accept Access Tokens as OAuth 2.0 Bearer Token Usage [RFC6750]."""
+
+        self.prepare_data("openid profile email address phone")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.post("/oauth/userinfo", headers=headers)
+        assert rv.headers["Content-Type"] == "application/json"
+
+        resp = json.loads(rv.data)
+        assert resp == {
+            "sub": "1",
+            "address": {
+                "country": "USA",
+                "formatted": "742 Evergreen Terrace, Springfield",
+                "locality": "Springfield",
+                "postal_code": "1245",
+                "region": "Unknown",
+                "street_address": "742 Evergreen Terrace",
+            },
+            "birthdate": "2000-12-01",
+            "email": "janedoe@example.com",
+            "email_verified": True,
+            "family_name": "Doe",
+            "gender": "female",
+            "given_name": "Jane",
+            "locale": "fr-FR",
+            "middle_name": "Middle",
+            "name": "foo",
+            "nickname": "Jany",
+            "phone_number": "+1 (425) 555-1212",
+            "phone_number_verified": False,
+            "picture": "https://example.com/janedoe/me.jpg",
+            "preferred_username": "j.doe",
+            "profile": "https://example.com/janedoe",
+            "updated_at": 1745315119,
+            "website": "https://example.com",
+            "zoneinfo": "Europe/Paris",
+        }
+
+    def test_no_token(self):
+        self.prepare_data()
+        rv = self.client.post("/oauth/userinfo")
+        resp = json.loads(rv.data)
+        assert resp["error"] == "missing_authorization"
+
+    def test_bad_token(self):
+        self.prepare_data()
+        headers = {"Authorization": "invalid token_string"}
+        rv = self.client.post("/oauth/userinfo", headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["error"] == "unsupported_token_type"
+
+    def test_token_has_bad_scope(self):
+        """Test that tokens without 'openid' scope cannot access the userinfo endpoint."""
+
+        self.prepare_data(token_scope="foobar")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.post("/oauth/userinfo", headers=headers)
+        resp = json.loads(rv.data)
+        assert resp["error"] == "insufficient_scope"
+
+    def test_scope_minimum(self):
+        self.prepare_data("openid")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        resp = json.loads(rv.data)
+        assert resp == {
+            "sub": "1",
+        }
+
+    def test_scope_profile(self):
+        self.prepare_data("openid profile")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        resp = json.loads(rv.data)
+        assert resp == {
+            "sub": "1",
+            "birthdate": "2000-12-01",
+            "family_name": "Doe",
+            "gender": "female",
+            "given_name": "Jane",
+            "locale": "fr-FR",
+            "middle_name": "Middle",
+            "name": "foo",
+            "nickname": "Jany",
+            "picture": "https://example.com/janedoe/me.jpg",
+            "preferred_username": "j.doe",
+            "profile": "https://example.com/janedoe",
+            "updated_at": 1745315119,
+            "website": "https://example.com",
+            "zoneinfo": "Europe/Paris",
+        }
+
+    def test_scope_address(self):
+        self.prepare_data("openid address")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        resp = json.loads(rv.data)
+        assert resp == {
+            "sub": "1",
+            "address": {
+                "country": "USA",
+                "formatted": "742 Evergreen Terrace, Springfield",
+                "locality": "Springfield",
+                "postal_code": "1245",
+                "region": "Unknown",
+                "street_address": "742 Evergreen Terrace",
+            },
+        }
+
+    def test_scope_email(self):
+        self.prepare_data("openid email")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        resp = json.loads(rv.data)
+        assert resp == {
+            "sub": "1",
+            "email": "janedoe@example.com",
+            "email_verified": True,
+        }
+
+    def test_scope_phone(self):
+        self.prepare_data("openid phone")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        resp = json.loads(rv.data)
+        assert resp == {
+            "sub": "1",
+            "phone_number": "+1 (425) 555-1212",
+            "phone_number_verified": False,
+        }
+
+    def test_scope_signed_unsecured(self):
+        """When userinfo_signed_response_alg is set as client metadata, the userinfo response must be a JWT."""
+        self.prepare_data("openid email", userinfo_signed_response_alg="none")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        assert rv.headers["Content-Type"] == "application/jwt"
+
+        claims = jwt.decode(rv.data, None)
+        assert claims == {
+            "sub": "1",
+            "iss": "https://auth.example",
+            "aud": "userinfo-client",
+            "email": "janedoe@example.com",
+            "email_verified": True,
+        }
+
+    def test_scope_signed_secured(self):
+        """When userinfo_signed_response_alg is set as client metadata and not none, the userinfo response must be signed."""
+        self.prepare_data("openid email", userinfo_signed_response_alg="RS256")
+        headers = {"Authorization": "Bearer access-token"}
+        rv = self.client.get("/oauth/userinfo", headers=headers)
+        assert rv.headers["Content-Type"] == "application/jwt"
+
+        pub_key = read_file_path("jwks_public.json")
+        claims = jwt.decode(rv.data, pub_key)
+        assert claims == {
+            "sub": "1",
+            "iss": "https://auth.example",
+            "aud": "userinfo-client",
+            "email": "janedoe@example.com",
+            "email_verified": True,
+        }


### PR DESCRIPTION
This PR implements the `UserInfoEndpoint` endpoint.
It also adds a `filter` method that restricts `UserInfo` claims to match a given scope.
Fixes #459