### PR TITLE
fix(starlette_client): remove default= keyword from config.get calls

### DIFF
--- a/authlib/integrations/starlette_client/integration.py
+++ b/authlib/integrations/starlette_client/integration.py
@@ -66,7 +66,7 @@ class StarletteIntegration(FrameworkIntegration):
         rv = {}
         for k in params:
             conf_key = f"{name}_{k}".upper()
-            v = oauth.config.get(conf_key, default=None)
+            v = oauth.config.get(conf_key)
             if v is not None:
                 rv[k] = v
         return rv


### PR DESCRIPTION
Authlib's Starlette integration was calling self.config.get(conf_key, default=None), which raises a TypeError when config is a plain dict. Changed all occurrences to use the positional form self.config.get(conf_key, None) so that both dicts and Config objects work seamlessly.

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
