### PR TITLE
docs(custom-claims): add documentation for custom claims class usage with ORCID example

### DIFF
--- a/docs/client/custom-claims.rst
+++ b/docs/client/custom-claims.rst
@@ -1,0 +1,45 @@
+.. _frameworks_clients:
+
+Custom Claims Class
+=================
+Since Authlib 1.5.2 there is the functionality to pass a custom claims class to authorize_access_token.
+
+This documentation demonstrates this feature by covering the special use case of authenticating with ORCID, a popular academic identity provider.
+
+ORCID has a non-standard response in the "amr" claim that returns a single string, rather than a list. Given the popularity of ORCID, this document specifies how to resolve this.
+
+Example: Log In with ORCID
+---------------------
+To do so, create a custom claims class:
+
+	from authlib.jose.errors import InvalidClaimError
+	from authlib.oidc.core import CodeIDToken
+
+	class ORCIDHandledToken(CodeIDToken):
+	    def validate_amr(self):
+	        """OPTIONAL. Authentication Methods References. JSON array of strings
+	        that are identifiers for authentication methods used in the
+	        authentication. For instance, values might indicate that both password
+	        and OTP authentication methods were used. The definition of particular
+	        values to be used in the amr Claim is beyond the scope of this
+	        specification. Parties using this claim will need to agree upon the
+	        meanings of the values used, which may be context-specific. The amr
+	        value is an array of case sensitive strings. However, ORCID sends
+	        just a string back and this causes a validation error. This patched
+	        version fixes it.
+	        """
+	        amr = self.get("amr")
+	        if amr and not isinstance(self["amr"], list | str):
+	            claim_error = "amr"
+	            raise InvalidClaimError(claim_error)
+
+
+Then, when fetching your token in the framework of your choice, pass your custom class:
+
+	token = oauth.cilogon.authorize_access_token(
+	            request, claims_cls=ORCIDHandledToken
+	        )
+
+The only difference to the original is the addition of the "| str" check which allows for lists and strings in the "amr" claim.
+
+See the underlying [IDToken code](/authlib/authlib/blob/main/authlib/oidc/core/claims.py) to determine which methods you can override.

--- a/docs/client/custom-claims.rst
+++ b/docs/client/custom-claims.rst
@@ -10,7 +10,7 @@ ORCID has a non-standard response in the "amr" claim that returns a single strin
 
 Example: Log In with ORCID
 ---------------------
-To do so, create a custom claims class:
+To do so, create a custom claims class::
 
 	from authlib.jose.errors import InvalidClaimError
 	from authlib.oidc.core import CodeIDToken
@@ -34,7 +34,7 @@ To do so, create a custom claims class:
 	            raise InvalidClaimError(claim_error)
 
 
-Then, when fetching your token in the framework of your choice, pass your custom class:
+Then, when fetching your token in the framework of your choice, pass your custom class::
 
 	token = oauth.cilogon.authorize_access_token(
 	            request, claims_cls=ORCIDHandledToken

--- a/docs/client/custom-claims.rst
+++ b/docs/client/custom-claims.rst
@@ -42,4 +42,4 @@ Then, when fetching your token in the framework of your choice, pass your custom
 
 The only difference to the original is the addition of the "| str" check which allows for lists and strings in the "amr" claim.
 
-See the underlying [IDToken code](/authlib/authlib/blob/main/authlib/oidc/core/claims.py) to determine which methods you can override.
+See the underlying `IDToken code <https://github.com/authlib/authlib/blob/main/authlib/oidc/core/claims.py>`_ to determine which methods you can override.

--- a/docs/client/orcid.rst
+++ b/docs/client/orcid.rst
@@ -1,0 +1,44 @@
+.. _frameworks_clients:
+
+Authenticating with ORCID
+=================
+
+This documentation covers the special use case of authenticating with ORCID, a popular academic identity provider.
+
+ORCID has a non-standard response in the "amr" claim that returns a single string, rather than a list. Given the popularity of ORCID, this document specifies how to resolve this.
+
+Log In with ORCID
+---------------------
+Since Authlib 1.5.2 there is the functionality to pass a custom claims class to authorize_access_token.
+
+To do so, create a custom claims class:
+
+	from authlib.jose.errors import InvalidClaimError
+	from authlib.oidc.core import CodeIDToken
+
+	class ORCIDHandledToken(CodeIDToken):
+	    def validate_amr(self):
+	        """OPTIONAL. Authentication Methods References. JSON array of strings
+	        that are identifiers for authentication methods used in the
+	        authentication. For instance, values might indicate that both password
+	        and OTP authentication methods were used. The definition of particular
+	        values to be used in the amr Claim is beyond the scope of this
+	        specification. Parties using this claim will need to agree upon the
+	        meanings of the values used, which may be context-specific. The amr
+	        value is an array of case sensitive strings. However, ORCID sends
+	        just a string back and this causes a validation error. This patched
+	        version fixes it.
+	        """
+	        amr = self.get("amr")
+	        if amr and not isinstance(self["amr"], list | str):
+	            claim_error = "amr"
+	            raise InvalidClaimError(claim_error)
+
+
+Then, when fetching your token in the framework of your choice, use:
+
+	token = oauth.cilogon.authorize_access_token(
+	            request, claims_cls=ORCIDHandledToken
+	        )
+
+The only difference to the original is the addition of the "| str" check which allows for lists and strings in the "amr" claim.


### PR DESCRIPTION
This PR creates documentation for using the new custom-claims feature, as per #725 

> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [X] Other, please describe: docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
