### PR TITLE
fix(ClientAuth): fix incorrect signature when Content-Type is x-www-form-urlencoded

### DIFF
--- a/authlib/oauth1/rfc5849/client_auth.py
+++ b/authlib/oauth1/rfc5849/client_auth.py
@@ -168,6 +168,8 @@ class ClientAuth(object):
 
         if CONTENT_TYPE_FORM_URLENCODED in content_type:
             headers['Content-Type'] = CONTENT_TYPE_FORM_URLENCODED
+            if isinstance(body, bytes):
+                body = body.decode()
             uri, headers, body = self.sign(method, uri, headers, body)
         elif self.force_include_body:
             # To allow custom clients to work on non form encoded bodies.


### PR DESCRIPTION
Decode body if body is bytes before signing. See issue https://github.com/authlib/authlib/issues/517 for details.

**What kind of change does this PR introduce?** (check at least one)

- [v] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [v] No

---

- [v] You consent that the copyright of your pull request source code belongs to Authlib's author.
