### PR TITLE
Temporarily restore OAuth2Request body parameter

### DIFF
--- a/authlib/integrations/django_oauth2/requests.py
+++ b/authlib/integrations/django_oauth2/requests.py
@@ -33,7 +33,11 @@ class DjangoOAuth2Payload(OAuth2Payload):
 
 class DjangoOAuth2Request(OAuth2Request):
     def __init__(self, request: HttpRequest):
-        super().__init__(request.method, request.build_absolute_uri(), request.headers)
+        super().__init__(
+            method=request.method,
+            uri=request.build_absolute_uri(),
+            headers=request.headers,
+        )
         self.payload = DjangoOAuth2Payload(request)
         self._request = request
 

--- a/authlib/integrations/flask_oauth2/requests.py
+++ b/authlib/integrations/flask_oauth2/requests.py
@@ -27,7 +27,9 @@ class FlaskOAuth2Payload(OAuth2Payload):
 
 class FlaskOAuth2Request(OAuth2Request):
     def __init__(self, request: Request):
-        super().__init__(request.method, request.url, request.headers)
+        super().__init__(
+            method=request.method, uri=request.url, headers=request.headers
+        )
         self._request = request
         self.payload = FlaskOAuth2Payload(request)
 

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -65,13 +65,22 @@ class BasicOAuth2Payload(OAuth2Payload):
 
 
 class OAuth2Request(OAuth2Payload):
-    def __init__(self, method: str, uri: str, headers=None):
+    def __init__(self, method: str, uri: str, body=None, headers=None):
         InsecureTransportError.check(uri)
         #: HTTP method
         self.method = method
         self.uri = uri
         #: HTTP headers
         self.headers = headers or {}
+
+        # Store body for backward compatibility but issue deprecation warning if used
+        if body is not None:
+            deprecate(
+                "'body' parameter in OAuth2Request is deprecated. "
+                "Use the payload system instead.",
+                version="1.8",
+            )
+        self._body = body
 
         self.payload = None
 
@@ -88,6 +97,8 @@ class OAuth2Request(OAuth2Payload):
 
     @property
     def form(self):
+        if self._body:
+            return self._body
         raise NotImplementedError()
 
     @property
@@ -153,6 +164,14 @@ class OAuth2Request(OAuth2Payload):
             version="1.8",
         )
         return self.payload.state
+
+    @property
+    def body(self):
+        deprecate(
+            "'request.body' is deprecated. Use the payload system instead.",
+            version="1.8",
+        )
+        return self._body
 
 
 class JsonPayload:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Version 1.6.1
 **Released on Jul 20, 2025**
 
 - Filter key set with additional "alg" and "use" parameters.
+- Restore and deprecate ``OAuth2Request`` ``body`` parameter. :issue:`781`
 
 Version 1.6.0
 -------------


### PR DESCRIPTION
This restores and deprecate the `OAuth2Request` parameter that have been removed with 1.6.0.
---
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
