### PR TITLE
Sign OIDC id_token  according to id_token_signed_response_alg client metadata

### DIFF
--- a/authlib/integrations/sqla_oauth2/client_mixin.py
+++ b/authlib/integrations/sqla_oauth2/client_mixin.py
@@ -110,6 +110,10 @@ class OAuth2ClientMixin(ClientMixin):
     def software_version(self):
         return self.client_metadata.get("software_version")
 
+    @property
+    def id_token_signed_response_alg(self):
+        return self.client_metadata.get("id_token_signed_response_alg")
+
     def get_client_id(self):
         return self.client_id
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,14 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.6.3
+-------------
+
+**Unreleased**
+
+- OIDC ``id_token`` are signed according to ``id_token_signed_response_alg``
+  client metadata. :issue:`755`
+
 Version 1.6.2
 -------------
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

The behavior to find the `alg` with which the id_token is signed is:
- use `alg` is set in `get_jwt_config` if defined
- else use `client.id_token_signed_response_alg` if defined
- else use the default `RS256`

I think `client.id_token_signed_response_alg` should take precedence over `get_jwt_config`, but that would be a breaking change. I will open another ticket for that, this could target v1.8.

Working on this part of the code made me realize that he `get_jwt_config` might be a little outdated. We would probably want use `get_server_jwks` instead here, instead of manually passing a key. What do you think?

fixes #755 

**Checklist**

- [x] You ran the linters with ``pre-commit``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
