### PR TITLE
RFC-9449: DPoP

### DIFF
--- a/authlib/common/cache.py
+++ b/authlib/common/cache.py
@@ -1,0 +1,66 @@
+from threading import Lock
+from typing import Dict, Generic, TypeVar
+
+
+class Node:
+    def __init__(self, key=None, value=None):
+        self.key = key
+        self.value = value
+        self.prev = None
+        self.next = None
+
+
+LRUCacheKey = TypeVar('LRUCacheKey')
+LRUCacheValue = TypeVar('LRUCacheValue')
+
+
+class LRUCache(Generic[LRUCacheKey, LRUCacheValue]):
+    def __init__(self, capacity: int):
+        self.maxsize = capacity
+        self.cache: Dict[LRUCacheKey, Node] = {}
+        self.head = Node()
+        self.tail = Node()
+        self.head.next = self.tail
+        self.tail.prev = self.head
+        self.lock = Lock()
+
+    def _add_node(self, node: Node):
+        node.prev = self.head
+        node.next = self.head.next
+        self.head.next.prev_nonce = node
+        self.head.next = node
+
+    @staticmethod
+    def _remove_node(node: Node):
+        prev = node.prev
+        new = node.next
+        prev.next_nonce = new
+        new.prev_nonce = prev
+
+    def _move_to_head(self, node: Node):
+        self._remove_node(node)
+        self._add_node(node)
+
+    def get(self, key: LRUCacheKey) -> LRUCacheValue:
+        with self.lock:
+            if key in self.cache:
+                node = self.cache[key]
+                self._move_to_head(node)
+                return node.value
+            else:
+                return None
+
+    def set(self, key: LRUCacheKey, value: LRUCacheValue):
+        with self.lock:
+            if key in self.cache:
+                node = self.cache[key]
+                node.value = value
+                self._move_to_head(node)
+            else:
+                new_node = Node(key, value)
+                self.cache[key] = new_node
+                self._add_node(new_node)
+                if len(self.cache) > self.maxsize:
+                    tail = self.tail.prev
+                    self._remove_node(tail)
+                    del self.cache[tail.key]

--- a/authlib/integrations/django_oauth2/requests.py
+++ b/authlib/integrations/django_oauth2/requests.py
@@ -12,6 +12,7 @@ from authlib.oauth2.rfc6749 import OAuth2Request
 
 class DjangoOAuth2Payload(OAuth2Payload):
     def __init__(self, request: HttpRequest):
+        super().__init__()
         self._request = request
 
     @cached_property

--- a/authlib/integrations/flask_oauth2/authorization_server.py
+++ b/authlib/integrations/flask_oauth2/authorization_server.py
@@ -11,6 +11,7 @@ from .requests import FlaskJsonRequest
 from .requests import FlaskOAuth2Request
 from .signals import client_authenticated
 from .signals import token_revoked
+from ...oauth2.rfc9449.token import DPoPTokenGenerator
 
 
 class AuthorizationServer(_AuthorizationServer):
@@ -129,7 +130,7 @@ class AuthorizationServer(_AuthorizationServer):
 
         expires_conf = config.get("OAUTH2_TOKEN_EXPIRES_IN")
         expires_generator = create_token_expires_in_generator(expires_conf)
-        return BearerTokenGenerator(
+        return DPoPTokenGenerator(
             access_token_generator, refresh_token_generator, expires_generator
         )
 

--- a/authlib/integrations/flask_oauth2/requests.py
+++ b/authlib/integrations/flask_oauth2/requests.py
@@ -11,6 +11,7 @@ from authlib.oauth2.rfc6749 import OAuth2Request
 
 class FlaskOAuth2Payload(OAuth2Payload):
     def __init__(self, request: Request):
+        super().__init__()
         self._request = request
 
     @property

--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -13,7 +13,7 @@ __all__ = ["AsyncAssertionClient"]
 
 
 class AsyncAssertionClient(_AssertionClient, httpx.AsyncClient):
-    token_auth_class = OAuth2Auth
+    auth_class = OAuth2Auth
     oauth_error_class = OAuthError
     JWT_BEARER_GRANT_TYPE = JWTBearerGrant.GRANT_TYPE
     ASSERTION_METHODS = {
@@ -58,7 +58,7 @@ class AsyncAssertionClient(_AssertionClient, httpx.AsyncClient):
             if not self.token or self.token.is_expired():
                 await self.refresh_token()
 
-            auth = self.token_auth
+            auth = self.protected_auth
         return await super().request(method, url, auth=auth, **kwargs)
 
     async def _refresh_token(self, data):
@@ -70,7 +70,7 @@ class AsyncAssertionClient(_AssertionClient, httpx.AsyncClient):
 
 
 class AssertionClient(_AssertionClient, httpx.Client):
-    token_auth_class = OAuth2Auth
+    auth_class = OAuth2Auth
     oauth_error_class = OAuthError
     JWT_BEARER_GRANT_TYPE = JWTBearerGrant.GRANT_TYPE
     ASSERTION_METHODS = {
@@ -120,5 +120,5 @@ class AssertionClient(_AssertionClient, httpx.Client):
             if not self.token or self.token.is_expired():
                 self.refresh_token()
 
-            auth = self.token_auth
+            auth = self.protected_auth
         return super().request(method, url, auth=auth, **kwargs)

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -31,9 +31,6 @@ __all__ = [
 class OAuth2DPoPAuthMixin(DPoPAuthProtocol):
     def retry_dpop_if_necessary(self, response: Response):
         request = response.request
-        if "DPoP-Nonce" in response.headers:
-            self.set_dpop_nonce(response.headers.get("DPoP-Nonce"))
-
         if self.is_dpop_error(response):
             url, headers, body = self.dpop_prepare(
                 request.method, str(request.url), request.headers, request.content
@@ -45,7 +42,7 @@ class OAuth2DPoPAuthMixin(DPoPAuthProtocol):
 
 
 class OAuth2Auth(Auth, TokenAuth, OAuth2DPoPAuthMixin):
-    """Sign requests for OAuth 2.0, currently only bearer token is supported."""
+    """Sign requests for OAuth 2.0, currently only bearer and dpop token are supported."""
 
     requires_request_body = True
     requires_response_body = True

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -3,85 +3,63 @@ from contextlib import asynccontextmanager
 
 import httpx
 from anyio import Lock  # Import after httpx so import errors refer to httpx
-from httpx import USE_CLIENT_DEFAULT
 from httpx import Auth
 from httpx import Request
 from httpx import Response
+from httpx import USE_CLIENT_DEFAULT
 
 from authlib.common.urls import url_decode
-from authlib.oauth2.auth import ClientAuth, DPoPAuthProtocol
-from authlib.oauth2.auth import TokenAuth
 from authlib.oauth2.client import OAuth2Client as _OAuth2Client
-
+from .utils import HTTPX_CLIENT_KWARGS
+from .utils import build_request
 from ..base_client import InvalidTokenError
 from ..base_client import MissingTokenError
 from ..base_client import OAuthError
-from ..base_client import UnsupportedTokenTypeError
-from .utils import HTTPX_CLIENT_KWARGS
-from .utils import build_request
+from ...oauth2.auth import AuthProtocol
 
 __all__ = [
     "OAuth2Auth",
-    "OAuth2ClientAuth",
     "AsyncOAuth2Client",
     "OAuth2Client",
 ]
 
 
-class OAuth2DPoPAuthMixin(DPoPAuthProtocol):
-    def retry_dpop_if_necessary(self, response: Response):
-        request = response.request
-        if self.is_dpop_error(response):
-            url, headers, body = self.dpop_prepare(
-                request.method, str(request.url), request.headers, request.content
-            )
-            headers["Content-Length"] = str(len(body))
-            yield build_request(
-                url=url, headers=headers, body=body, initial_request=request
-            )
-
-
-class OAuth2Auth(Auth, TokenAuth, OAuth2DPoPAuthMixin):
-    """Sign requests for OAuth 2.0, currently only bearer and dpop token are supported."""
+class OAuth2Auth(Auth):
+    """Sign requests for OAuth 2.0"""
 
     requires_request_body = True
     requires_response_body = True
 
-    def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
-        try:
-            url, headers, body = self.prepare(
-                request.method, str(request.url), request.headers, request.content
-            )
-            headers["Content-Length"] = str(len(body))
-            response = yield build_request(
-                url=url, headers=headers, body=body, initial_request=request
-            )
-            yield from self.retry_dpop_if_necessary(response)
-        except KeyError as error:
-            description = f"Unsupported token_type: {str(error)}"
-            raise UnsupportedTokenTypeError(description=description) from error
-
-
-class OAuth2ClientAuth(Auth, ClientAuth, OAuth2DPoPAuthMixin):
-    requires_request_body = True
-    requires_response_body = True
+    def __init__(self, auth: AuthProtocol):
+        self.auth = auth
 
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:
-        url, headers, body = self.prepare(
+        url, headers, body = self.auth.prepare(
             request.method, str(request.url), request.headers, request.content
         )
         headers["Content-Length"] = str(len(body))
         response = yield build_request(
             url=url, headers=headers, body=body, initial_request=request
         )
-        yield from self.retry_dpop_if_necessary(response)
+        yield from self.retry_if_necessary(response)
+
+    def retry_if_necessary(self, response: Response):
+        if not self.auth.should_retry(response):
+            return
+        request = response.request
+        url, headers, body = self.auth.prepare_retry(
+            request.method, str(request.url), request.headers, request.content
+        )
+        headers["Content-Length"] = str(len(body))
+        yield build_request(
+            url=url, headers=headers, body=body, initial_request=request
+        )
 
 
 class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
     SESSION_REQUEST_PARAMS = HTTPX_CLIENT_KWARGS
 
-    client_auth_class = OAuth2ClientAuth
-    token_auth_class = OAuth2Auth
+    auth_class = OAuth2Auth
     oauth_error_class = OAuthError
 
     def __init__(
@@ -133,7 +111,7 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
 
             await self.ensure_active_token(self.token)
 
-            auth = self.token_auth
+            auth = self.protected_auth
 
         return await super().request(method, url, auth=auth, **kwargs)
 
@@ -147,7 +125,7 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
 
             await self.ensure_active_token(self.token)
 
-            auth = self.token_auth
+            auth = self.protected_auth
 
         async with super().stream(method, url, auth=auth, **kwargs) as resp:
             yield resp
@@ -230,8 +208,7 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
 class OAuth2Client(_OAuth2Client, httpx.Client):
     SESSION_REQUEST_PARAMS = HTTPX_CLIENT_KWARGS
 
-    client_auth_class = OAuth2ClientAuth
-    token_auth_class = OAuth2Auth
+    auth_class = OAuth2Auth
     oauth_error_class = OAuthError
 
     def __init__(
@@ -285,7 +262,7 @@ class OAuth2Client(_OAuth2Client, httpx.Client):
             if not self.ensure_active_token(self.token):
                 raise InvalidTokenError()
 
-            auth = self.token_auth
+            auth = self.protected_auth
 
         return super().request(method, url, auth=auth, **kwargs)
 
@@ -299,6 +276,6 @@ class OAuth2Client(_OAuth2Client, httpx.Client):
             if not self.ensure_active_token(self.token):
                 raise InvalidTokenError()
 
-            auth = self.token_auth
+            auth = self.protected_auth
 
         return super().stream(method, url, auth=auth, **kwargs)

--- a/authlib/integrations/requests_client/assertion_session.py
+++ b/authlib/integrations/requests_client/assertion_session.py
@@ -2,12 +2,11 @@ from requests import Session
 
 from authlib.oauth2.rfc7521 import AssertionClient
 from authlib.oauth2.rfc7523 import JWTBearerGrant
-
-from .oauth2_session import OAuth2Auth
 from .utils import update_session_configure
+from ...oauth2 import TokenAuth
 
 
-class AssertionAuth(OAuth2Auth):
+class AssertionAuth(TokenAuth):
     def ensure_active_token(self):
         if self.client and (
             not self.token or self.token.is_expired(self.client.leeway)
@@ -66,5 +65,5 @@ class AssertionSession(AssertionClient, Session):
         if self.default_timeout:
             kwargs.setdefault("timeout", self.default_timeout)
         if not withhold_token and auth is None:
-            auth = self.token_auth
+            auth = self.protected_auth
         return super().request(method, url, auth=auth, **kwargs)

--- a/authlib/jose/rfc7515/jws.py
+++ b/authlib/jose/rfc7515/jws.py
@@ -11,6 +11,7 @@ from authlib.jose.util import ensure_dict
 from authlib.jose.util import extract_header
 from authlib.jose.util import extract_segment
 
+from .models import JWSAlgorithm
 from .models import JWSHeader
 from .models import JWSObject
 
@@ -45,6 +46,12 @@ class JsonWebSignature:
         if not algorithm or algorithm.algorithm_type != "JWS":
             raise ValueError(f"Invalid algorithm for JWS, {algorithm!r}")
         cls.ALGORITHMS_REGISTRY[algorithm.name] = algorithm
+
+    @classmethod
+    def get_algorithm(cls, alg: str) -> JWSAlgorithm:
+        if alg not in cls.ALGORITHMS_REGISTRY:
+            raise UnsupportedAlgorithmError()
+        return cls.ALGORITHMS_REGISTRY[alg]
 
     def serialize_compact(self, protected, payload, key):
         """Generate a JWS Compact Serialization. The JWS Compact Serialization

--- a/authlib/jose/rfc7515/models.py
+++ b/authlib/jose/rfc7515/models.py
@@ -7,9 +7,13 @@ class JWSAlgorithm:
     description = None
     algorithm_type = "JWS"
     algorithm_location = "alg"
+    key_cls = None
 
     def prepare_key(self, raw_data):
         """Prepare key for signing and verifying signature."""
+        raise NotImplementedError()
+
+    def generate_key(self, options=None, is_private=False):
         raise NotImplementedError()
 
     def sign(self, msg, key):

--- a/authlib/jose/rfc7516/models.py
+++ b/authlib/jose/rfc7516/models.py
@@ -15,6 +15,9 @@ class JWEAlgorithmBase(metaclass=ABCMeta):  # noqa: B024
     def prepare_key(self, raw_data):
         raise NotImplementedError
 
+    def generate_key(self, options=None, is_private=False):
+        raise NotImplementedError
+
     def generate_preset(self, enc_alg, key):
         raise NotImplementedError
 

--- a/authlib/jose/rfc7517/jwk.py
+++ b/authlib/jose/rfc7517/jwk.py
@@ -1,3 +1,5 @@
+from authlib.jose import JsonWebSignature
+
 from authlib.common.encoding import json_loads
 
 from ._cryptography_key import load_pem_key
@@ -19,6 +21,11 @@ class JsonWebKey:
         """
         key_cls = cls.JWK_KEY_CLS[kty]
         return key_cls.generate_key(crv_or_size, options, is_private)
+
+    @classmethod
+    def generate_key_from_jws_alg(cls, alg, options=None, is_private=False):
+        algorithm = JsonWebSignature.get_algorithm(alg)
+        return algorithm.generate_key(options=options, is_private=is_private)
 
     @classmethod
     def import_key(cls, raw, options=None):

--- a/authlib/jose/rfc7518/jws_algs.py
+++ b/authlib/jose/rfc7518/jws_algs.py
@@ -31,6 +31,9 @@ class NoneAlgorithm(JWSAlgorithm):
     def prepare_key(self, raw_data):
         return None
 
+    def generate_key(self, options=None, is_private=False):
+        return None
+
     def sign(self, msg, key):
         return b""
 
@@ -49,14 +52,19 @@ class HMACAlgorithm(JWSAlgorithm):
     SHA256 = hashlib.sha256
     SHA384 = hashlib.sha384
     SHA512 = hashlib.sha512
+    key_cls = OctKey
 
     def __init__(self, sha_type):
+        self.size = sha_type
         self.name = f"HS{sha_type}"
         self.description = f"HMAC using SHA-{sha_type}"
         self.hash_alg = getattr(self, f"SHA{sha_type}")
 
     def prepare_key(self, raw_data):
         return OctKey.import_key(raw_data)
+
+    def generate_key(self, options=None, is_private=False):
+        return OctKey.generate_key(self.size, options, is_private)
 
     def sign(self, msg, key):
         # it is faster than the one in cryptography
@@ -80,8 +88,10 @@ class RSAAlgorithm(JWSAlgorithm):
     SHA256 = hashes.SHA256
     SHA384 = hashes.SHA384
     SHA512 = hashes.SHA512
+    key_cls = RSAKey
 
     def __init__(self, sha_type):
+        self.size = sha_type
         self.name = f"RS{sha_type}"
         self.description = f"RSASSA-PKCS1-v1_5 using SHA-{sha_type}"
         self.hash_alg = getattr(self, f"SHA{sha_type}")
@@ -89,6 +99,9 @@ class RSAAlgorithm(JWSAlgorithm):
 
     def prepare_key(self, raw_data):
         return RSAKey.import_key(raw_data)
+
+    def generate_key(self, options=None, is_private=False):
+        return RSAKey.generate_key(self.size, options, is_private)
 
     def sign(self, msg, key):
         op_key = key.get_op_key("sign")
@@ -114,6 +127,7 @@ class ECAlgorithm(JWSAlgorithm):
     SHA256 = hashes.SHA256
     SHA384 = hashes.SHA384
     SHA512 = hashes.SHA512
+    key_cls = ECKey
 
     def __init__(self, name, curve, sha_type):
         self.name = name
@@ -128,6 +142,9 @@ class ECAlgorithm(JWSAlgorithm):
                 f'Key for "{self.name}" not supported, only "{self.curve}" allowed'
             )
         return key
+
+    def generate_key(self, options=None, is_private=False):
+        return ECKey.generate_key(self.curve, options, is_private)
 
     def sign(self, msg, key):
         op_key = key.get_op_key("sign")
@@ -166,8 +183,10 @@ class RSAPSSAlgorithm(JWSAlgorithm):
     SHA256 = hashes.SHA256
     SHA384 = hashes.SHA384
     SHA512 = hashes.SHA512
+    key_cls = RSAKey
 
     def __init__(self, sha_type):
+        self.size = sha_type
         self.name = f"PS{sha_type}"
         tpl = "RSASSA-PSS using SHA-{} and MGF1 with SHA-{}"
         self.description = tpl.format(sha_type, sha_type)
@@ -175,6 +194,9 @@ class RSAPSSAlgorithm(JWSAlgorithm):
 
     def prepare_key(self, raw_data):
         return RSAKey.import_key(raw_data)
+
+    def generate_key(self, options=None, is_private=False):
+        return RSAKey.generate_key(self.size, options, is_private)
 
     def sign(self, msg, key):
         op_key = key.get_op_key("sign")

--- a/authlib/jose/rfc7519/jwt.py
+++ b/authlib/jose/rfc7519/jwt.py
@@ -168,6 +168,9 @@ def find_encode_key(key, header):
 
 
 def create_load_key(key):
+    if not key:
+        return key
+
     def load_key(header, payload):
         if isinstance(key, KeySet):
             return key.find_by_kid(header.get("kid"))

--- a/authlib/oauth2/auth.py
+++ b/authlib/oauth2/auth.py
@@ -98,6 +98,9 @@ class DPoPAuthMixin(DPoPAuthProtocol):
         return uri, headers, body
 
     def is_dpop_error(self, response):
+        if "DPoP-Nonce" in response.headers:
+            self.set_dpop_nonce(response.headers.get("DPoP-Nonce"))
+
         return self.dpop_error_validator(response)
 
 
@@ -171,7 +174,8 @@ class TokenAuth(DPoPAuthMixin, AuthProtocol):
             self.token["access_token"], uri, headers, body, self.token_placement
         )
 
-        uri, headers, body = self.dpop_prepare(method, uri, headers, body)
+        if token_type.lower() == "dpop":
+            uri, headers, body = self.dpop_prepare(method, uri, headers, body)
 
         for hook in self.hooks:
             uri, headers, body = hook(uri, headers, body)

--- a/authlib/oauth2/auth.py
+++ b/authlib/oauth2/auth.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Any, Callable, Protocol
 
 from authlib.common.encoding import to_bytes
 from authlib.common.encoding import to_native
@@ -7,6 +8,8 @@ from authlib.common.urls import add_params_to_uri
 
 from .rfc6749 import OAuth2Token
 from .rfc6750 import add_bearer_token
+from .rfc9449 import add_dpop_token
+from .rfc9449.proof import DPoPProof
 
 
 def encode_client_secret_basic(client, method, uri, headers, body):
@@ -39,7 +42,66 @@ def encode_none(client, method, uri, headers, body):
     return uri, headers, body
 
 
-class ClientAuth:
+class AuthProtocol(Protocol):
+    def prepare(self, method, uri, headers, body) -> tuple[Any, Any, Any]:
+        ...
+
+
+def is_auth_server_dpop_error(response):
+    if response.status_code == 400:
+        body = response.json()
+        if "error" in body and body["error"] == "use_dpop_nonce":
+            return True
+    return False
+
+
+def is_resource_server_dpop_error(response):
+    return response.status_code == 401 and "use_dpop_nonce" in response.headers.get("www-authenticate", "")
+
+
+class DPoPAuthProtocol(Protocol):
+    DEFAULT_DPOP_NONCE_KEY: DPoPProof.NonceKey = None
+
+    def set_dpop_nonce(self, nonce):
+        ...
+
+    def dpop_prepare(self, method, uri, headers, body) -> tuple[Any, Any, Any]:
+        ...
+
+    def is_dpop_error(self, response) -> Callable:
+        ...
+
+
+class DPoPAuthMixin(DPoPAuthProtocol):
+    def __init__(self, dpop_error_validator, dpop_proof=None):
+        self.nonce = None
+        if not callable(dpop_error_validator):
+            raise ValueError("dpop_error_validator is not a callable function")
+        self.dpop_error_validator = dpop_error_validator
+        self.dpop_proof = dpop_proof
+
+    def set_dpop_nonce(self, nonce):
+        self.dpop_proof.set_nonce(self.DEFAULT_DPOP_NONCE_KEY, nonce)
+
+    def dpop_prepare(self, method, uri, headers, body):
+        if self.dpop_proof:
+            token = None
+            if hasattr(self, 'token'):
+                token = self.token
+            uri, headers, body = self.dpop_proof.prepare(
+                method,
+                uri,
+                headers,
+                body,
+                nonce_key=self.DEFAULT_DPOP_NONCE_KEY,
+                token=token)
+        return uri, headers, body
+
+    def is_dpop_error(self, response):
+        return self.dpop_error_validator(response)
+
+
+class ClientAuth(DPoPAuthMixin, AuthProtocol):
     """Attaches OAuth Client Information to HTTP requests.
 
     :param client_id: Client ID, which you get from client registration.
@@ -51,14 +113,14 @@ class ClientAuth:
         * client_secret_post
         * none
     """
-
+    DEFAULT_DPOP_NONCE_KEY = DPoPProof.NonceKey.AUTH_SERVER_NONCE_KEY
     DEFAULT_AUTH_METHODS = {
         "client_secret_basic": encode_client_secret_basic,
         "client_secret_post": encode_client_secret_post,
         "none": encode_none,
     }
 
-    def __init__(self, client_id, client_secret, auth_method=None):
+    def __init__(self, client_id, client_secret, auth_method=None, dpop_proof=None):
         if auth_method is None:
             auth_method = "client_secret_basic"
 
@@ -69,12 +131,14 @@ class ClientAuth:
             auth_method = self.DEFAULT_AUTH_METHODS[auth_method]
 
         self.auth_method = auth_method
+        super().__init__(is_auth_server_dpop_error, dpop_proof=dpop_proof)
 
     def prepare(self, method, uri, headers, body):
-        return self.auth_method(self, method, uri, headers, body)
+        uri, headers, body = self.auth_method(self, method, uri, headers, body)
+        return self.dpop_prepare(method, uri, headers, body)
 
 
-class TokenAuth:
+class TokenAuth(DPoPAuthMixin, AuthProtocol):
     """Attach token information to HTTP requests.
 
     :param token: A dict or OAuth2Token instance of an OAuth 2.0 token
@@ -86,24 +150,28 @@ class TokenAuth:
         * uri
     """
 
+    DEFAULT_DPOP_NONCE_KEY = DPoPProof.NonceKey.RESOURCE_SERVER_NONCE_KEY
     DEFAULT_TOKEN_TYPE = "bearer"
-    SIGN_METHODS = {"bearer": add_bearer_token}
+    SIGN_METHODS = {"bearer": add_bearer_token, "dpop": add_dpop_token}
 
-    def __init__(self, token, token_placement="header", client=None):
+    def __init__(self, token, token_placement="header", client=None, dpop_proof=None):
         self.token = OAuth2Token.from_dict(token)
         self.token_placement = token_placement
         self.client = client
         self.hooks = set()
+        super().__init__(is_resource_server_dpop_error, dpop_proof=dpop_proof)
 
     def set_token(self, token):
         self.token = OAuth2Token.from_dict(token)
 
-    def prepare(self, uri, headers, body):
+    def prepare(self, method, uri, headers, body):
         token_type = self.token.get("token_type", self.DEFAULT_TOKEN_TYPE)
         sign = self.SIGN_METHODS[token_type.lower()]
         uri, headers, body = sign(
             self.token["access_token"], uri, headers, body, self.token_placement
         )
+
+        uri, headers, body = self.dpop_prepare(method, uri, headers, body)
 
         for hook in self.hooks:
             uri, headers, body = hook(uri, headers, body)

--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -180,6 +180,9 @@ class OAuth2Client:
             kwargs["code_challenge"] = create_s256_code_challenge(code_verifier)
             kwargs["code_challenge_method"] = self.code_challenge_method
 
+        if self.dpop_proof:
+            kwargs["dpop_jkt"] = self.dpop_proof.jwk.thumbprint()
+
         for k in self.EXTRA_AUTHORIZE_PARAMS:
             if k not in kwargs and k in self.metadata:
                 kwargs[k] = self.metadata[k]

--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -267,6 +267,7 @@ class AuthorizationServer(Hookable):
             raise
         return grant
 
+    @hooked
     def get_token_grant(self, request):
         """Find the token grant for current request.
 

--- a/authlib/oauth2/rfc6749/errors.py
+++ b/authlib/oauth2/rfc6749/errors.py
@@ -36,6 +36,7 @@ from authlib.oauth2.base import OAuth2Error
 
 __all__ = [
     "OAuth2Error",
+    "ForbiddenError",
     "InsecureTransportError",
     "InvalidRequestError",
     "InvalidClientError",
@@ -195,17 +196,20 @@ class AccessDeniedError(OAuth2Error):
 class ForbiddenError(OAuth2Error):
     status_code = 401
 
-    def __init__(self, auth_type=None, realm=None):
-        super().__init__()
+    def __init__(self, description=None, auth_type=None, realm=None, status_code=None):
+        super().__init__(description=description, status_code=status_code)
         self.auth_type = auth_type
         self.realm = realm
+
+    def get_extras(self):
+        return []
 
     def get_headers(self):
         headers = super().get_headers()
         if not self.auth_type:
             return headers
 
-        extras = []
+        extras = self.get_extras()
         if self.realm:
             extras.append(f'realm="{self.realm}"')
         extras.append(f'error="{self.error}"')

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -9,10 +9,14 @@ Access Token per `Section 6`_.
 
 import logging
 
-from .base import BaseGrant, TokenEndpointMixin
-from ..errors import InvalidGrantError, InvalidRequestError, InvalidScopeError, UnauthorizedClientError
+from ..errors import InvalidGrantError
+from ..errors import InvalidRequestError
+from ..errors import InvalidScopeError
+from ..errors import UnauthorizedClientError
 from ..hooks import hooked
 from ..util import scope_to_list
+from .base import BaseGrant
+from .base import TokenEndpointMixin
 
 log = logging.getLogger(__name__)
 

--- a/authlib/oauth2/rfc6749/grants/refresh_token.py
+++ b/authlib/oauth2/rfc6749/grants/refresh_token.py
@@ -9,14 +9,10 @@ Access Token per `Section 6`_.
 
 import logging
 
-from ..errors import InvalidGrantError
-from ..errors import InvalidRequestError
-from ..errors import InvalidScopeError
-from ..errors import UnauthorizedClientError
+from .base import BaseGrant, TokenEndpointMixin
+from ..errors import InvalidGrantError, InvalidRequestError, InvalidScopeError, UnauthorizedClientError
 from ..hooks import hooked
 from ..util import scope_to_list
-from .base import BaseGrant
-from .base import TokenEndpointMixin
 
 log = logging.getLogger(__name__)
 
@@ -70,6 +66,7 @@ class RefreshTokenGrant(BaseGrant, TokenEndpointMixin):
         if not original_scope.issuperset(set(scope_to_list(scope))):
             raise InvalidScopeError()
 
+    @hooked
     def validate_token_request(self):
         """If the authorization server issued a refresh token to the client, the
         client makes a refresh request to the token endpoint by adding the

--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -165,16 +165,6 @@ class AuthorizationCodeMixin:
         """
         raise NotImplementedError()
 
-    def get_dpop_jkt(self):
-        """A method to get the DPoP jkt associated with this code:
-
-        .. code-block::
-
-            def get_dpop_jkt(self):
-                return self.dpop_jkt
-        """
-        return None
-
 
 class TokenMixin:
     def check_client(self, client):
@@ -261,13 +251,3 @@ class TokenMixin:
                 return self.token_type
         """
         raise NotImplementedError()
-
-    def get_dpop_jkt(self):
-        """A method to get the DPoP jkt associated with this token:
-
-        .. code-block::
-
-            def get_dpop_jkt(self):
-                return self.dpop_jkt
-        """
-        return None

--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -165,6 +165,16 @@ class AuthorizationCodeMixin:
         """
         raise NotImplementedError()
 
+    def get_dpop_jkt(self):
+        """A method to get the DPoP jkt associated with this code:
+
+        .. code-block::
+
+            def get_dpop_jkt(self):
+                return self.dpop_jkt
+        """
+        return None
+
 
 class TokenMixin:
     def check_client(self, client):
@@ -241,3 +251,23 @@ class TokenMixin:
                 return Client.get(self.client_id)
         """
         raise NotImplementedError()
+
+    def get_token_type(self):
+        """A method to get the token type associated with this token:
+
+        .. code-block::
+
+            def get_token_type(self):
+                return self.token_type
+        """
+        raise NotImplementedError()
+
+    def get_dpop_jkt(self):
+        """A method to get the DPoP jkt associated with this token:
+
+        .. code-block::
+
+            def get_dpop_jkt(self):
+                return self.dpop_jkt
+        """
+        return None

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -1,11 +1,13 @@
 from collections import defaultdict
 
 from authlib.deprecate import deprecate
-
 from .errors import InsecureTransportError
 
 
 class OAuth2Payload:
+    def __init__(self):
+        self._dpop_jkt = None
+
     @property
     def data(self):
         raise NotImplementedError()
@@ -49,9 +51,20 @@ class OAuth2Payload:
     def state(self):
         return self.data.get("state")
 
+    @property
+    def dpop_jkt(self):
+        if self._dpop_jkt:
+            return self._dpop_jkt
+        return self.data.get("dpop_jkt")
+
+    @dpop_jkt.setter
+    def dpop_jkt(self, value):
+        self._dpop_jkt = value
+
 
 class BasicOAuth2Payload(OAuth2Payload):
     def __init__(self, payload):
+        super().__init__()
         self._data = payload
         self._datalist = {key: [value] for key, value in payload.items()}
 
@@ -66,6 +79,7 @@ class BasicOAuth2Payload(OAuth2Payload):
 
 class OAuth2Request(OAuth2Payload):
     def __init__(self, method: str, uri: str, body=None, headers=None):
+        super().__init__()
         InsecureTransportError.check(uri)
         #: HTTP method
         self.method = method

--- a/authlib/oauth2/rfc6750/errors.py
+++ b/authlib/oauth2/rfc6750/errors.py
@@ -40,10 +40,12 @@ class InvalidTokenError(OAuth2Error):
         status_code=None,
         state=None,
         realm=None,
+        token_type="Bearer",
         **extra_attributes,
     ):
         super().__init__(description, uri, status_code, state)
         self.realm = realm
+        self.token_type = token_type
         self.extra_attributes = extra_attributes
 
     def get_headers(self):
@@ -67,7 +69,7 @@ class InvalidTokenError(OAuth2Error):
         extras.append(f'error="{self.error}"')
         error_description = self.get_error_description()
         extras.append(f'error_description="{error_description}"')
-        headers.append(("WWW-Authenticate", "Bearer " + ", ".join(extras)))
+        headers.append(("WWW-Authenticate", f"{self.token_type} " + ", ".join(extras)))
         return headers
 
 

--- a/authlib/oauth2/rfc6750/token.py
+++ b/authlib/oauth2/rfc6750/token.py
@@ -1,4 +1,8 @@
-class BearerTokenGenerator:
+class TokenGenerator:
+    TOKEN_TYPE = None
+
+
+class BearerTokenGenerator(TokenGenerator):
     """Bearer token generator which can create the payload for token response
     by OAuth 2 server. A typical token response would be:
 
@@ -17,6 +21,7 @@ class BearerTokenGenerator:
         }
     """
 
+    TOKEN_TYPE = "Bearer"
     #: default expires_in value
     DEFAULT_EXPIRES_IN = 3600
     #: default expires_in value differentiate by grant_type
@@ -83,7 +88,7 @@ class BearerTokenGenerator:
             expires_in = self._get_expires_in(client, grant_type)
 
         token = {
-            "token_type": "Bearer",
+            "token_type": self.TOKEN_TYPE,
             "access_token": access_token,
         }
         if expires_in:

--- a/authlib/oauth2/rfc7521/client.py
+++ b/authlib/oauth2/rfc7521/client.py
@@ -1,4 +1,6 @@
 from authlib.common.encoding import to_native
+from authlib.oauth2 import TokenAuth
+from authlib.oauth2.auth import create_auth
 from authlib.oauth2.base import OAuth2Error
 
 
@@ -11,7 +13,8 @@ class AssertionClient:
 
     DEFAULT_GRANT_TYPE = None
     ASSERTION_METHODS = {}
-    token_auth_class = None
+    auth_class = None
+    token_auth_class = TokenAuth
     oauth_error_class = OAuth2Error
 
     def __init__(
@@ -46,10 +49,13 @@ class AssertionClient:
         self.audience = audience
         self.claims = claims
         self.scope = scope
-        if self.token_auth_class is not None:
-            self.token_auth = self.token_auth_class(None, token_placement, self)
+        self.token_auth = self.token_auth_class(None, token_placement)
         self._kwargs = kwargs
         self.leeway = leeway
+
+    @property
+    def protected_auth(self):
+        return self.auth_class(create_auth(self.token_auth))
 
     @property
     def token(self):

--- a/authlib/oauth2/rfc7662/token_validator.py
+++ b/authlib/oauth2/rfc7662/token_validator.py
@@ -1,6 +1,6 @@
-from ..rfc6749 import TokenValidator
-from ..rfc6750 import InsufficientScopeError
-from ..rfc6750 import InvalidTokenError
+from ..rfc6749.resource_protector import TokenValidator
+from ..rfc6750.errors import InsufficientScopeError
+from ..rfc6750.errors import InvalidTokenError
 
 
 class IntrospectTokenValidator(TokenValidator):

--- a/authlib/oauth2/rfc8414/models.py
+++ b/authlib/oauth2/rfc8414/models.py
@@ -33,7 +33,6 @@ class AuthorizationServerMetadata(dict):
         "introspection_endpoint_auth_methods_supported",
         "introspection_endpoint_auth_signing_alg_values_supported",
         "code_challenge_methods_supported",
-        "dpop_signing_alg_values_supported",
     ]
 
     def validate_issuer(self):
@@ -318,17 +317,6 @@ class AuthorizationServerMetadata(dict):
         """
         validate_array_value(self, "code_challenge_methods_supported")
 
-    def validate_dpop_signing_alg_values_supported(self):
-        """OPTIONAL.  A JSON array containing a list of the JWS alg values
-         (from the [IANA.JOSE.ALGS] registry) supported by the authorization
-          server for DPoP proof JWTs.
-        """
-        _validate_alg_values(
-            self,
-            "dpop_signing_alg_values_supported",
-            self.dpop_signing_alg_values_supported,
-        )
-
     @property
     def response_modes_supported(self):
         #: If omitted, the default is ["query", "fragment"]
@@ -395,3 +383,10 @@ def validate_array_value(metadata, key):
     values = metadata.get(key)
     if values is not None and not isinstance(values, list):
         raise ValueError(f'"{key}" MUST be JSON array')
+
+
+def _validate_boolean_value(metadata, key):
+    if key not in metadata:
+        return
+    if metadata[key] not in (True, False):
+        raise ValueError(f'"{key}" MUST be boolean')

--- a/authlib/oauth2/rfc8414/models.py
+++ b/authlib/oauth2/rfc8414/models.py
@@ -33,6 +33,7 @@ class AuthorizationServerMetadata(dict):
         "introspection_endpoint_auth_methods_supported",
         "introspection_endpoint_auth_signing_alg_values_supported",
         "code_challenge_methods_supported",
+        "dpop_signing_alg_values_supported",
     ]
 
     def validate_issuer(self):
@@ -316,6 +317,17 @@ class AuthorizationServerMetadata(dict):
         does not support PKCE.
         """
         validate_array_value(self, "code_challenge_methods_supported")
+
+    def validate_dpop_signing_alg_values_supported(self):
+        """OPTIONAL.  A JSON array containing a list of the JWS alg values
+         (from the [IANA.JOSE.ALGS] registry) supported by the authorization
+          server for DPoP proof JWTs.
+        """
+        _validate_alg_values(
+            self,
+            "dpop_signing_alg_values_supported",
+            self.dpop_signing_alg_values_supported,
+        )
 
     @property
     def response_modes_supported(self):

--- a/authlib/oauth2/rfc9449/__init__.py
+++ b/authlib/oauth2/rfc9449/__init__.py
@@ -6,12 +6,20 @@ The OAuth 2.0 Demonstrating Proof of Possession (DPoP).
 
 https://tools.ietf.org/html/rfc9449
 """
-from .errors import InvalidDPoPKeyBindingError, InvalidDPopProofError, UseDPoPNonceError
-from .nonce import DPoPNonceCache, DPoPNonceGenerator, DefaultDPoPNonceCache, DefaultDPoPNonceGenerator
+from .errors import InvalidDPoPKeyBindingError
+from .errors import InvalidDPopProofError
+from .errors import UseDPoPNonceError
+from .nonce import DPoPNonceCache
+from .nonce import DPoPNonceGenerator
+from .nonce import DefaultDPoPNonceCache
+from .nonce import DefaultDPoPNonceGenerator
 from .parameters import add_dpop_token
 from .proof import DPoPProof
 from .token import DPoPTokenGenerator
-from .validator import DPoP, DPoPProofValidator, DPoPTokenValidator, normalize_url
+from .grants import DPoPGrantExtension
+from .validator import DPoPProofValidator
+from .validator import DPoPTokenValidator
+from .validator import normalize_url
 
 __all__ = [
     "add_dpop_token",
@@ -27,6 +35,6 @@ __all__ = [
     "DPoPTokenGenerator",
     "DPoPProofValidator",
     "DPoPTokenValidator",
-    "DPoP",
+    "DPoPGrantExtension",
 ]
 

--- a/authlib/oauth2/rfc9449/__init__.py
+++ b/authlib/oauth2/rfc9449/__init__.py
@@ -6,9 +6,27 @@ The OAuth 2.0 Demonstrating Proof of Possession (DPoP).
 
 https://tools.ietf.org/html/rfc9449
 """
-
+from .errors import InvalidDPoPKeyBindingError, InvalidDPopProofError, UseDPoPNonceError
+from .nonce import DPoPNonceCache, DPoPNonceGenerator, DefaultDPoPNonceCache, DefaultDPoPNonceGenerator
 from .parameters import add_dpop_token
+from .proof import DPoPProof
+from .token import DPoPTokenGenerator
+from .validator import DPoP, DPoPProofValidator, DPoPTokenValidator, normalize_url
 
 __all__ = [
     "add_dpop_token",
+    "normalize_url",
+    "InvalidDPopProofError",
+    "UseDPoPNonceError",
+    "InvalidDPoPKeyBindingError",
+    "DPoPNonceCache",
+    "DefaultDPoPNonceCache",
+    "DPoPNonceGenerator",
+    "DefaultDPoPNonceGenerator",
+    "DPoPProof",
+    "DPoPTokenGenerator",
+    "DPoPProofValidator",
+    "DPoPTokenValidator",
+    "DPoP",
 ]
+

--- a/authlib/oauth2/rfc9449/__init__.py
+++ b/authlib/oauth2/rfc9449/__init__.py
@@ -1,0 +1,14 @@
+"""authlib.oauth2.rfc9449.
+~~~~~~~~~~~~~~~~~~~~~~
+
+This module represents a direct implementation of
+The OAuth 2.0 Demonstrating Proof of Possession (DPoP).
+
+https://tools.ietf.org/html/rfc9449
+"""
+
+from .parameters import add_dpop_token
+
+__all__ = [
+    "add_dpop_token",
+]

--- a/authlib/oauth2/rfc9449/auth.py
+++ b/authlib/oauth2/rfc9449/auth.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from authlib.oauth2.auth import AuthProtocol
+from authlib.oauth2.rfc9449 import DPoPProof
+
+
+def is_auth_server_dpop_error(response) -> bool:
+    if response.status_code == 400:
+        body = response.json()
+        if "error" in body and body["error"] == "use_dpop_nonce":
+            return True
+    return False
+
+
+def is_resource_server_dpop_error(response) -> bool:
+    return response.status_code == 401 and "use_dpop_nonce" in response.headers.get("www-authenticate", "")
+
+
+class DPoPAuth(AuthProtocol):
+    def __init__(self, dpop_proof: DPoPProof):
+        self.dpop_proof = dpop_proof
+
+    def prepare(self, method, uri, headers, body) -> tuple[Any, Any, Any]:
+        access_token = None
+        if "Authorization" in headers:
+            _, access_token = headers["Authorization"].split()
+        return self.dpop_proof.prepare(
+            method,
+            uri,
+            headers,
+            body,
+            nonce_origin=uri,
+            access_token=access_token)
+
+    def prepare_retry(self, method, uri, headers, body) -> tuple[Any, Any, Any]:
+        return self.prepare(method, uri, headers, body)
+
+    def should_retry(self, response) -> bool:
+        if "DPoP-Nonce" in response.headers:
+            self.dpop_proof.set_nonce(str(response.url), response.headers["DPoP-Nonce"])
+
+        return is_resource_server_dpop_error(response) or is_auth_server_dpop_error(response)

--- a/authlib/oauth2/rfc9449/authorization_server.py
+++ b/authlib/oauth2/rfc9449/authorization_server.py
@@ -1,0 +1,49 @@
+from authlib.oauth2 import AuthorizationServer
+from authlib.oauth2 import OAuth2Request
+from authlib.oauth2.rfc6749 import AuthorizationCodeGrant
+from authlib.oauth2.rfc6749 import BaseGrant
+from authlib.oauth2.rfc6749 import ClientMixin
+from authlib.oauth2.rfc6749 import InvalidRequestError
+from authlib.oauth2.rfc6749 import RefreshTokenGrant
+from authlib.oauth2.rfc9449.grants import DPoPGrantExtension
+from authlib.oauth2.rfc9449.registration import ClientMetadataClaims
+from authlib.oauth2.rfc9449.validator import DPoPProofValidator
+
+
+class DPoP:
+    def __init__(self, proof_validator: DPoPProofValidator):
+        self.proof_validator = proof_validator
+
+    def __call__(self, server: AuthorizationServer):
+        server.register_hook("after_get_authorization_grant", self.add_dpop_extension)
+        server.register_hook("after_get_token_grant", self.add_dpop_extension_and_confirm_dpop)
+
+    def add_dpop_extension(self, server: AuthorizationServer, grant: BaseGrant):
+        if isinstance(grant, AuthorizationCodeGrant) or isinstance(grant, RefreshTokenGrant):
+            dpop_grant_extension = DPoPGrantExtension(self.proof_validator)
+            dpop_grant_extension(grant)
+
+    def add_dpop_extension_and_confirm_dpop(self, server: AuthorizationServer, grant: BaseGrant):
+        client = grant.authenticate_token_endpoint_client()
+        client_metadata = self.get_client_metadata(client)
+        request: OAuth2Request = grant.request
+        if client_metadata and client_metadata.dpop_bound_access_tokens and "DPoP" not in request.headers:
+            raise InvalidRequestError(
+                "Token requests for this client must use DPoP.",
+                state=request.payload.state,
+            )
+
+        self.add_dpop_extension(server, grant)
+
+    def get_client_metadata(self, client: ClientMixin) -> ClientMetadataClaims:
+        """Return the client metadata.
+        When the ``dpop_bound_access_tokens`` claim is :data:`True`,
+        the client must use DPoP for token requests.
+        If omitted, the default value is false.::
+            class DPoP(rfc9449.DPoP):
+                def get_client_metadata(self):
+                    return ClientMetadataClaims({
+                        "dpop_bound_access_tokens": ...,
+                    })
+        """
+        return ClientMetadataClaims()

--- a/authlib/oauth2/rfc9449/discovery.py
+++ b/authlib/oauth2/rfc9449/discovery.py
@@ -1,0 +1,23 @@
+from authlib.oauth2.rfc8414.models import _validate_alg_values
+
+
+class AuthorizationServerMetadata(dict):
+    REGISTRY_KEYS = ["dpop_signing_alg_values_supported"]
+
+    def validate_dpop_signing_alg_values_supported(self):
+        """OPTIONAL.  A JSON array containing a list of the JWS alg values
+        (from the [IANA.JOSE.ALGS] registry) supported by the authorization
+        server for DPoP proof JWTs.
+        """
+        _validate_alg_values(
+            self,
+            "dpop_signing_alg_values_supported",
+            self.dpop_signing_alg_values_supported,
+        )
+
+    @property
+    def dpop_signing_alg_values_supported(self):
+        #: If omitted, the set of JWS alg values MUST be
+        #: determined by other means
+        #: here, we use "ES256"
+        return self.get("dpop_signing_alg_values_supported", ["ES256"])

--- a/authlib/oauth2/rfc9449/errors.py
+++ b/authlib/oauth2/rfc9449/errors.py
@@ -1,0 +1,67 @@
+"""authlib.oauth2.rfc9449.errors.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
+
+from authlib.oauth2.rfc6749.errors import ForbiddenError
+
+__all__ = [
+    "InvalidDPopProofError",
+    "UseDPoPNonceError",
+    "InvalidDPoPKeyBindingError",
+]
+
+
+class OAuth2DPoPError(ForbiddenError):
+    def __init__(self, description: str = None, for_resource: bool = False):
+        self.for_resource = for_resource
+        status_code = 401 if for_resource else 400
+        super().__init__(description, auth_type="DPoP", status_code=status_code)
+
+    def get_body(self):
+        if self.for_resource:
+            return []
+        return super().get_body()
+
+
+class InvalidDPopProofError(OAuth2DPoPError):
+    error = "invalid_dpop_proof"
+
+    def __init__(self, description: str = None, algs: list[str] = None, for_resource: bool = False):
+        self.algs = " ".join(algs)
+        super().__init__(description=description, for_resource=for_resource)
+
+    def get_extras(self):
+        extras = super().get_extras()
+        extras.append(f'algs="{self.algs}"')
+        return extras
+
+
+class UseDPoPNonceError(OAuth2DPoPError):
+    error = "use_dpop_nonce"
+
+    def __init__(self, dpop_nonce, description=None, for_resource=False):
+        if not description:
+            server_type = "Resource" if for_resource else "Authorization"
+            description = f"{server_type} server requires nonce in DPoP proof"
+        super().__init__(description=description, for_resource=for_resource)
+        self.dpop_nonce = dpop_nonce
+
+    def get_headers(self):
+        headers = super().get_headers()
+        headers.append(("DPoP-Nonce", self.dpop_nonce))
+        return headers
+
+
+class InvalidDPoPKeyBindingError(OAuth2DPoPError):
+    error = "invalid_token"
+    description = "Invalid DPoP key binding"
+
+    def __init__(self, algs: list[str] = None):
+        self.algs = " ".join(algs)
+        super().__init__(for_resource=True)
+
+    def get_extras(self):
+        extras = super().get_extras()
+        extras.append(f'algs="{self.algs}"')
+        return extras

--- a/authlib/oauth2/rfc9449/grants.py
+++ b/authlib/oauth2/rfc9449/grants.py
@@ -1,0 +1,36 @@
+from authlib.oauth2.rfc6749 import InvalidGrantError
+from authlib.oauth2.rfc6749.requests import OAuth2Request
+from authlib.oauth2.rfc9449.validator import DPoPProofValidator
+
+
+class DPoPGrantExtension:
+    def __init__(self, proof_validator: DPoPProofValidator):
+        """DPoP extension to Authorization Code Grant and Refresh Token Grant.
+        It enables a client to prove the possession of a public/private key pair
+        by including a DPoP header in an HTTP request.
+
+        The AuthorizationCodeGrant MUST save the ``dpop_jkt`` attribute from the
+        OAuth2Request into database when ``save_authorization_code``.
+        """
+        self.proof_validator = proof_validator
+
+    def __call__(self, grant):
+        grant.register_hook("after_validate_token_request", self.validate_dpop_jkt)
+
+    def validate_dpop_jkt(self, grant, _):
+        request: OAuth2Request = grant.request
+
+        existing_jkt = None
+        if hasattr(request, "authorization_code") and request.authorization_code:
+            existing_jkt = request.authorization_code.get_dpop_jkt()
+        elif hasattr(request, "refresh_token") and request.refresh_token:
+            existing_jkt = request.refresh_token.get_dpop_jkt()
+
+        if existing_jkt and "DPoP" not in request.headers:
+            raise InvalidGrantError("DPoP proof is required for this request")
+
+        dpop_header_jkt = self.proof_validator.validate_proof(request)
+
+        if existing_jkt != dpop_header_jkt:
+            raise InvalidGrantError("DPoP proof does not match the expected JKT")
+        request.dpop_jkt = dpop_header_jkt

--- a/authlib/oauth2/rfc9449/models.py
+++ b/authlib/oauth2/rfc9449/models.py
@@ -1,0 +1,22 @@
+class AuthorizationCodeMixin:
+    def get_dpop_jkt(self):
+        """A method to get the DPoP jkt associated with this code:
+
+        .. code-block::
+
+            def get_dpop_jkt(self):
+                return self.dpop_jkt
+        """
+        return None
+
+
+class TokenMixin:
+    def get_dpop_jkt(self):
+        """A method to get the DPoP jkt associated with this token:
+
+        .. code-block::
+
+            def get_dpop_jkt(self):
+                return self.dpop_jkt
+        """
+        return None

--- a/authlib/oauth2/rfc9449/nonce.py
+++ b/authlib/oauth2/rfc9449/nonce.py
@@ -1,0 +1,106 @@
+import time
+from threading import Lock
+from typing import Protocol
+
+from authlib.common.cache import LRUCache
+from authlib.common.security import generate_token
+
+
+class DPoPNonceCache(Protocol):
+    def __getitem__(self, origin: str) -> str:
+        """
+        Get the nonce saved for a specific origin url
+        :param origin: the url of the nonce to get
+        :return: the nonce
+        """
+        ...
+
+    def __setitem__(self, origin: str, nonce: str) -> None:
+        """
+        Set a nonce for the specific origin url
+        :param origin: the url of the nonce to set
+        :param nonce: the nonce to set
+        """
+        ...
+
+
+class DPoPNonceGenerator(Protocol):
+    def next(self) -> str:
+        """
+        Compute and return the next nonce for this server
+        :return: the nonce
+        """
+        ...
+
+    def check(self, nonce: str) -> bool:
+        """
+        Checks if a nonce is valid
+        :param nonce: the nonce
+        :return: if the nonce is valid
+        """
+        ...
+
+
+class DefaultDPoPNonceCache(DPoPNonceCache):
+    """
+    A default implementation of a DPoPNonceCache utilizing an LRUCache
+    """
+    DEFAULT_CACHE_CAPACITY = 100
+
+    def __init__(self, capacity: int = DEFAULT_CACHE_CAPACITY):
+        self.lru_cache = LRUCache[str, str](capacity)
+
+    def __getitem__(self, origin: str) -> str:
+        return self.lru_cache.get(origin)
+
+    def __setitem__(self, origin: str, nonce: str):
+        self.lru_cache.set(origin, nonce)
+
+
+class DefaultDPoPNonceGenerator(DPoPNonceGenerator):
+    """
+    A default implementation of a DPoPNonceGenerator
+    """
+    DEFAULT_MAX_AGE = 3 * 60  # 3 minutes
+
+    def __init__(self, max_age: int = DEFAULT_MAX_AGE):
+        self.interval = max_age / 3
+        self.counter = self._current_counter()
+        self.prev_nonce = self._compute(self.counter - 1)
+        self.cur_nonce = self._compute(self.counter)
+        self.next_nonce = self._compute(self.counter + 1)
+        self.lock = Lock()
+
+    def next(self) -> str:
+        self._rotate()
+        return self.next_nonce
+
+    def check(self, nonce: str) -> bool:
+        return self.next_nonce == nonce or self.cur_nonce == nonce or self.prev_nonce == nonce
+
+    def _current_counter(self) -> int:
+        return int(time.time() / self.interval)
+
+    def _rotate(self):
+        with self.lock:
+            counter = self._current_counter()
+            match counter - self.counter:
+                case 0:
+                    pass
+                case 1:
+                    self.prev_nonce = self.cur_nonce
+                    self.cur_nonce = self.next_nonce
+                    self.next_nonce = self._compute(counter + 1)
+                case 2:
+                    self.prev_nonce = self.next_nonce
+                    self.cur_nonce = self._compute(counter)
+                    self.next_nonce = self._compute(counter + 1)
+                case 3:
+                    self.prev_nonce = self._compute(counter - 1)
+                    self.cur_nonce = self._compute(counter)
+                    self.next_nonce = self._compute(counter + 1)
+            self.counter = counter
+
+    @staticmethod
+    def _compute(counter: int) -> str:
+        return generate_token()

--- a/authlib/oauth2/rfc9449/parameters.py
+++ b/authlib/oauth2/rfc9449/parameters.py
@@ -1,0 +1,20 @@
+from authlib.common.urls import add_params_to_qs
+from authlib.common.urls import add_params_to_uri
+
+
+def add_to_headers(token, headers=None):
+    """Add a DPoP Token to the request headers
+
+    Authorization: DPoP h480djs93hd8
+    """
+    headers = headers or {}
+    headers["Authorization"] = f"DPoP {token}"
+    return headers
+
+
+def add_dpop_token(token, uri, headers, body, placement="header"):
+    if placement in ("header", "headers"):
+        headers = add_to_headers(token, headers)
+    else:
+        raise ValueError("Unsupported placement") # TODO: Custom error
+    return uri, headers, body

--- a/authlib/oauth2/rfc9449/proof.py
+++ b/authlib/oauth2/rfc9449/proof.py
@@ -1,0 +1,153 @@
+import json
+import time
+import traceback
+from enum import Enum
+
+from authlib.common.security import generate_token
+from authlib.jose import JsonWebKey, jwt
+from authlib.oauth2.rfc6749 import OAuth2Token
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+
+
+def generate_ec_p256_jwk(options=None):
+    return JsonWebKey.generate_key("EC", "P-256", options=options, is_private=True)
+
+
+# Key could come from a provided token as a string
+# or internally, so should pass it as a string
+# Header:
+#   typ: dpop+jwt
+#   alg: <alg>
+#   jwk: <jwk public key>
+# Payload:
+#   jti: generate_token()
+#   htm: method
+#   htu: url
+#   iat: time.time()
+#   ath: <token> # Optional
+#   nonce: <nonce> # Optional
+def sign_dpop_proof(
+        jwk,
+        alg,
+        method,
+        url,
+        nonce=None,
+        token=None,
+        claims=None,
+        headers=None,
+        expires_in=30,
+):
+    header = {
+        "typ": "dpop+jwt",
+        "alg": alg,
+        "jwk": json.loads(jwk.as_json(is_private=False)),
+    }
+
+    if headers:
+        header.update(headers)
+
+    now = time.time()
+    payload = {
+        "jti": generate_token(36),
+        "htm": method,
+        "htu": url,
+        "iat": int(now),
+    }
+
+    if expires_in:
+        payload["exp"] = now + expires_in
+
+    if token:
+        payload["ath"] = create_s256_code_challenge(token["access_token"])
+
+    if nonce:
+        payload["nonce"] = nonce
+
+    if claims:
+        payload.update(claims)
+
+    return jwt.encode(header, payload, jwk).decode("utf-8")
+
+
+class DPoPProof:
+    name = "dpop_proof"
+    DEFAULT_ALGORITHM = "ES256"
+    DEFAULT_JWK_GENERATOR = generate_ec_p256_jwk
+
+    class NonceKey(Enum):
+        AUTH_SERVER_NONCE_KEY = "auth_server"
+        RESOURCE_SERVER_NONCE_KEY = "resource_server"
+
+    def __init__(
+            self,
+            jwk=None,
+            claims=None,
+            headers=None,
+            alg=DEFAULT_ALGORITHM,
+            jwk_generator=DEFAULT_JWK_GENERATOR,
+            jwk_generator_options=None,
+            update_nonces=None,
+            auth_server_nonce=None,
+            resource_server_nonce=None):
+        self.claims = claims
+        self.headers = headers
+        self.alg = alg
+        self.jwk = jwk
+
+        if not callable(jwk_generator):
+            raise ValueError("jwk_generator is not a callable function")
+        self.jwk_generator = jwk_generator
+        self.jwk_generator_options = jwk_generator_options
+
+        if update_nonces and not callable(update_nonces):
+            raise ValueError("update_nonces is not a callable function")
+        self.update_nonces = update_nonces
+
+        self.nonces = {
+            self.NonceKey.AUTH_SERVER_NONCE_KEY: auth_server_nonce,
+            self.NonceKey.RESOURCE_SERVER_NONCE_KEY: resource_server_nonce
+        }
+        self.token = None
+
+    def set_nonce(self, key: NonceKey, nonce):
+        if key not in self.NonceKey:
+            return
+
+        cur_nonce = None
+        if key in self.nonces:
+            cur_nonce = self.nonces[key]
+
+        self.nonces[key] = nonce
+
+        if cur_nonce != nonce:
+            self._emit_nonces()
+
+    def set_token(self, token):
+        self.token = OAuth2Token.from_dict(token)
+        self._emit_nonces()
+        if not self.jwk:
+            if token and "dpop_jwk" in token:
+                self.jwk = JsonWebKey.import_key(token["dpop_jwk"])
+            elif self.jwk is None:
+                self.jwk = self.jwk_generator(self.jwk_generator_options)
+
+    def prepare(self, method, uri, headers, body, nonce_key: NonceKey = None, token=None):
+        nonce = None
+        if nonce_key and nonce_key in self.nonces:
+            nonce = self.nonces[nonce_key]
+
+        proof = sign_dpop_proof(self.jwk,
+                                self.alg,
+                                method,
+                                uri,
+                                nonce=nonce,
+                                token=token,
+                                claims=self.claims,
+                                headers=self.headers)
+        headers = headers or {}
+        headers["DPoP"] = f"{proof}"
+        return uri, headers, body
+
+    def _emit_nonces(self):
+        if self.token and self.update_nonces:
+            self.update_nonces(self.token, self.nonces)

--- a/authlib/oauth2/rfc9449/proof.py
+++ b/authlib/oauth2/rfc9449/proof.py
@@ -119,17 +119,20 @@ class DPoPProof:
 
         self.nonces[key] = nonce
 
-        if cur_nonce != nonce:
+        if cur_nonce != nonce and key is self.NonceKey.RESOURCE_SERVER_NONCE_KEY:
+            # AUTH_SERVER_NONCE_KEY is already emitted via update_token
             self._emit_nonces()
+
+    def generate_jwk(self, token):
+        self.set_token(token)
+        if not self.jwk:
+            if self.token and "dpop_jwk" in self.token:
+                self.jwk = JsonWebKey.import_key(self.token["dpop_jwk"])
+            elif self.jwk is None:
+                self.jwk = self.jwk_generator(self.jwk_generator_options)
 
     def set_token(self, token):
         self.token = OAuth2Token.from_dict(token)
-        self._emit_nonces()
-        if not self.jwk:
-            if token and "dpop_jwk" in token:
-                self.jwk = JsonWebKey.import_key(token["dpop_jwk"])
-            elif self.jwk is None:
-                self.jwk = self.jwk_generator(self.jwk_generator_options)
 
     def prepare(self, method, uri, headers, body, nonce_key: NonceKey = None, token=None):
         nonce = None

--- a/authlib/oauth2/rfc9449/proof.py
+++ b/authlib/oauth2/rfc9449/proof.py
@@ -86,12 +86,12 @@ class DPoPProof:
         """
         Initialize the DPoPProof signing with prepopulated values.
 
-        :param jwk: the JWK keypair used to sign this proof
-        :param claims: optional additional payload claims to include
-        :param headers: optional additional header claims to include
-        :param preferred_alg: the preferred algorithm to use when creating the JWK, defaults to ES256
-        :param jwk_options: additional options to provide when creating the JWK
-        :param nonce_cache: a custom DPoPNonceCache to use, defaults to DefaultDPoPNonceCache
+        :param jwk: the JWK keypair used to sign this proof.
+        :param claims: optional additional payload claims to include.
+        :param headers: optional additional header claims to include.
+        :param preferred_alg: the preferred algorithm to use when creating the JWK, defaults to ES256.
+        :param jwk_options: additional options to provide when creating the JWK.
+        :param nonce_cache: a custom DPoPNonceCache to use, defaults to DefaultDPoPNonceCache.
         """
         self.claims = claims
         self.headers = headers
@@ -123,11 +123,8 @@ class DPoPProof:
                 self.alg = self._negotiate_algorithm(supported_algs)
                 self.jwk = JsonWebKey.generate_key_from_jws_alg(self.alg, self.jwk_options, True)
 
-    def prepare(self, method, uri, headers, body, nonce_origin=None, token=None):
+    def prepare(self, method, uri, headers, body, nonce_origin=None, access_token=None):
         nonce = self.nonce_cache[nonce_origin]
-        access_token = None
-        if token:
-            access_token = token["access_token"]
         proof = sign_dpop_proof(self.jwk,
                                 self.alg,
                                 method,

--- a/authlib/oauth2/rfc9449/registration.py
+++ b/authlib/oauth2/rfc9449/registration.py
@@ -1,0 +1,46 @@
+from authlib.oauth2.rfc8414.models import _validate_boolean_value
+
+
+class ClientMetadataClaims(dict):
+    """Additional client metadata can be used with :ref:`specs/rfc7591` and :ref:`specs/rfc7592` endpoints.
+
+    This can be used with::
+
+        server.register_endpoint(
+            ClientRegistrationEndpoint(
+                claims_classes=[
+                    rfc7591.ClientMetadataClaims,
+                    rfc9449.ClientMetadataClaims,
+                ]
+            )
+        )
+
+        server.register_endpoint(
+            ClientRegistrationEndpoint(
+                claims_classes=[
+                    rfc7591.ClientMetadataClaims,
+                    rfc9449.ClientMetadataClaims,
+                ]
+            )
+        )
+
+    """
+
+    REGISTERED_CLAIMS = [
+        "dpop_bound_access_tokens",
+    ]
+
+    def validate(self):
+        self.validate_dpop_bound_access_tokens()
+
+    def validate_dpop_bound_access_tokens(self):
+        """A boolean value specifying whether the client always
+        uses DPoP for token requests.
+        If omitted, the default value is false.
+        """
+        _validate_boolean_value(self, "dpop_bound_access_tokens")
+
+    @property
+    def dpop_bound_access_tokens(self):
+        # If omitted, the default value is false.
+        return self.get("dpop_bound_access_tokens", False)

--- a/authlib/oauth2/rfc9449/token.py
+++ b/authlib/oauth2/rfc9449/token.py
@@ -1,4 +1,4 @@
-from authlib.oauth2.rfc6750 import BearerTokenGenerator
+from authlib.oauth2.rfc6750.token import BearerTokenGenerator
 
 
 class DPoPTokenGenerator(BearerTokenGenerator):

--- a/authlib/oauth2/rfc9449/token.py
+++ b/authlib/oauth2/rfc9449/token.py
@@ -1,0 +1,31 @@
+from authlib.oauth2.rfc6750 import BearerTokenGenerator
+
+
+class DPoPTokenGenerator(BearerTokenGenerator):
+    """DPoP token generator which can create the payload for token response
+    by OAuth 2 server. A typical token response would be:
+
+    .. code-block:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json;charset=UTF-8
+        Cache-Control: no-store
+        Pragma: no-cache
+
+        {
+            "access_token":"mF_9.B5f-4.1JqM",
+            "token_type":"DPoP",
+            "expires_in":3600,
+            "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA"
+        }
+    """
+
+    TOKEN_TYPE = "DPoP"
+
+    def __init__(
+        self,
+        access_token_generator,
+        refresh_token_generator=None,
+        expires_generator=None,
+    ):
+        super().__init__(access_token_generator, refresh_token_generator, expires_generator)

--- a/authlib/oauth2/rfc9449/validator.py
+++ b/authlib/oauth2/rfc9449/validator.py
@@ -1,0 +1,216 @@
+"""authlib.oauth2.rfc9449.validator.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Validate DPoP Token and Proof.
+"""
+from urllib.parse import urlparse
+
+from authlib.jose import JoseError, JsonWebKey, jwt
+from authlib.oauth2.rfc6749 import InvalidGrantError, OAuth2Request, TokenMixin
+from authlib.oauth2.rfc6750 import BearerTokenValidator
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+from .errors import InvalidDPoPKeyBindingError, InvalidDPopProofError, UseDPoPNonceError
+from .nonce import DPoPNonceGenerator
+
+
+def normalize_url(url):
+    """
+    The HTTP URI of the request (without query and fragment parts)
+    .. _`Section 4.2`: https://datatracker.ietf.org/doc/html/rfc9449#section-4.2
+    """
+    return urlparse(url)._replace(query="", fragment="").geturl()
+
+
+class DPoPProofValidator:
+    DEFAULT_SUPPORTED_ALGS = ["ES256"]
+
+    def __init__(self, nonce_generator: DPoPNonceGenerator = None, algs: list[str] = None, claims_options: dict = None):
+        """Validates that a DPoP Proof is correctly formed for the request.
+
+        :param nonce_generator: generates and manages the current nonces, and checks for a valid nonce when provided
+        :param algs: the list of algorithms that this DPoP implementation supports
+        :param claims_options: any custom claims validation necessary for this server
+
+        .. _`Section 4.3`: https://datatracker.ietf.org/doc/html/rfc9449#section-4.3
+        """
+        self.nonce_generator = nonce_generator
+        self.algs = algs or self.DEFAULT_SUPPORTED_ALGS
+        self.claims_options = claims_options or {}
+
+    def validate_proof(self, request: OAuth2Request, access_token: str = None, for_resource: bool = False) -> str:
+        """
+        To validate a DPoP proof, the receiving server MUST ensure the following:
+        1. There is not more than one DPoP HTTP request header field.
+        2. The DPoP HTTP request header field value is a single and well-formed JWT.
+        3. All required claims per Section 4.2 are contained in the JWT.
+        4. The typ JOSE Header Parameter has the value dpop+jwt.
+        5. The alg JOSE Header Parameter indicates a registered asymmetric
+            digital signature algorithm [IANA.JOSE.ALGS], is not none, is
+            supported by the application, and is acceptable per local
+            policy.
+        6. The JWT signature verifies with the public key contained in the
+            jwk JOSE Header Parameter.
+        7. The jwk JOSE Header Parameter does not contain a private key.
+        8. The htm claim matches the HTTP method of the current request.
+        9. The htu claim matches the HTTP URI value for the HTTP request in
+            which the JWT was received, ignoring any query and fragment
+            parts.
+        10. If the server provided a nonce value to the client, the nonce
+            claim matches the server-provided nonce value.
+        11. The creation time of the JWT, as determined by either the iat
+            claim or a server managed timestamp via the nonce claim, is
+            within an acceptable window (see Section 11.1).
+        12. If presented to a protected resource in conjunction with an
+            access token,
+            *   ensure that the value of the ath claim equals the hash of
+                that access token, and
+            *   confirm that the public key to which the access token is
+                bound matches the public key from the DPoP proof.
+
+        To reduce the likelihood of false negatives, servers SHOULD employ
+        syntax-based normalization (Section 6.2.2 of [RFC3986]) and scheme-
+        based normalization (Section 6.2.3 of [RFC3986]) before comparing the
+        htu claim.
+
+        These checks may be performed in any order.
+
+        :param request: the current request
+        :param access_token: the access token being used to access a protected resource
+        :param for_resource: whether or not we're validating for a protected resource or not
+        :return: thumbprint of the public key from the DPoP proof
+        :raise: InvalidDPopProofError
+        :raise: UseDPoPNonceError
+
+        .. _`Section 4.3`: https://datatracker.ietf.org/doc/html/rfc9449#section-4.3
+        """
+        if "DPoP" not in request.headers:
+            raise InvalidDPopProofError("DPoP proof required", algs=self.algs, for_resource=for_resource)
+
+        proof = request.headers["DPoP"]
+        # Validation 1
+        if len(proof.split(",")) > 1:
+            raise InvalidDPopProofError("DPoP header must contain a single proof", algs=self.algs,
+                                        for_resource=for_resource)
+
+        uri = normalize_url(request.uri)
+
+        claims_options = {
+            "jti": {"essential": True},
+            "iat": {"essential": True},  # Validation 11 # TODO: nonce timestamp?? Not sure what that means
+            "htm": {"essential": True, "value": request.method},  # Validation 8
+            "htu": {"essential": True, "value": uri},  # Validation 9
+        }
+
+        if access_token:
+            ath = create_s256_code_challenge(access_token)
+            claims_options["ath"] = {"essential": True, "value": ath}  # Validation 12a
+
+        try:
+            self.claims_options.update(claims_options)
+            # Validation 2, 3, 6
+            claims = jwt.decode(proof, None, claims_options=self.claims_options)
+            claims.validate(leeway=30)
+        except JoseError as error:
+            raise InvalidDPopProofError(description=f"DPoP {error.description.lower()}", algs=self.algs,
+                                        for_resource=for_resource)
+
+        header = claims.header
+        key = JsonWebKey.import_key(header["jwk"])
+        self.validate_header(header, for_resource=for_resource)
+
+        # Validation 7
+        if not key.public_only:
+            raise InvalidDPopProofError("DPoP 'jwk' not a public key",
+                                        algs=self.algs,
+                                        for_resource=for_resource)
+
+        if self.nonce_generator:
+            if "nonce" not in claims:
+                raise UseDPoPNonceError(self.nonce_generator.next(), for_resource=for_resource)
+            elif not self.nonce_generator.check(claims["nonce"]):
+                raise UseDPoPNonceError(self.nonce_generator.next(), description=f"DPoP invalid claim 'nonce'",
+                                        for_resource=for_resource)
+
+        return key.thumbprint()
+
+    def validate_header(self, header: dict, for_resource: bool = False):
+        """A method to validate if the DPoP proof header contains additional claims. Developers MAY
+        re-implement this method.
+
+        :param header: the header extracted from the DPoP proof
+        :param for_resource: whether or not we're validating for a protected resource or not
+        :raise: InvalidDPopProofError
+        """
+        # Validation 4
+        if "typ" not in header or header["typ"] != "dpop+jwt":
+            raise InvalidDPopProofError("DPoP 'typ' header not 'dpop+jwt'",
+                                        algs=self.algs,
+                                        for_resource=for_resource)
+
+        # Validation 5
+        if "alg" not in header or header["alg"] not in self.algs:
+            raise InvalidDPopProofError(f"DPoP 'alg' header not in {self.algs}", algs=self.algs,
+                                        for_resource=for_resource)
+
+
+class DPoP:
+    def __init__(self, proof_validator: DPoPProofValidator):
+        """DPoP extension to Authorization Code Grant and Refresh Token Grant.
+        It enables a client to prove the possession of a public/private key pair
+        by including a DPoP header in an HTTP request.
+
+        The AuthorizationCodeGrant MUST save the ``dpop_jkt`` attribute from the
+        OAuth2Request into database when ``save_authorization_code``.
+
+        Then register this extension via::
+
+            server.register_grant(AuthorizationCodeGrant, [DPoP(proof_validator=dpop_proof_validator)])
+            server.register_grant(RefreshTokenGrant, [DPoP(proof_validator=dpop_proof_validator)])
+        """
+        self.proof_validator = proof_validator
+
+    def __call__(self, grant):
+        grant.register_hook(
+            "after_validate_token_request",
+            self.validate_dpop_jkt,
+        )
+
+    def validate_dpop_jkt(self, grant, _):
+        request: OAuth2Request = grant.request
+
+        existing_jkt = None
+        if hasattr(request, "authorization_code") and request.authorization_code:
+            existing_jkt = request.authorization_code.get_dpop_jkt()
+        elif hasattr(request, "refresh_token") and request.refresh_token:
+            existing_jkt = request.refresh_token.get_dpop_jkt()
+
+        if existing_jkt and "DPoP" not in request.headers:
+            raise InvalidGrantError("DPoP proof is required for this request")
+
+        dpop_header_jkt = self.proof_validator.validate_proof(request)
+
+        if existing_jkt != dpop_header_jkt:
+            raise InvalidGrantError("DPoP proof does not match the expected JKT")
+        request.dpop_jkt = dpop_header_jkt
+
+
+class DPoPTokenValidator(BearerTokenValidator):
+    TOKEN_TYPE = "dpop"
+
+    def __init__(self, proof_validator: DPoPProofValidator):
+        super().__init__()
+        self.proof_validator = proof_validator
+
+    def validate_token(self, token: TokenMixin, scopes: list[str], request):
+        """Validates the DPoP proof against the stored access token"""
+        super().validate_token(token, scopes, request)
+        access_token = request.headers.get("Authorization").split()[1]
+        dpop_header_thumbprint = self.proof_validator.validate_proof(
+            request,
+            access_token=access_token,
+            for_resource=True)
+        dpop_token_thumbprint = token.get_dpop_jkt()
+
+        if dpop_header_thumbprint != dpop_token_thumbprint:
+            # Validation 12b
+            raise InvalidDPoPKeyBindingError(self.proof_validator.algs)


### PR DESCRIPTION
This is a WIP to request feedback early on in the approach before I clean things up, write tests, and submit an official PR.

This implements [RFC-9449: OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449), #315 .

I'm supporting ATProto (Bluesky) in my application, and their implementation requires DPoP and PAR (which I also have a change I'm testing that I'll put up as a WIP PR later). You can read more about their specific requirements [here](https://docs.bsky.app/docs/advanced-guides/oauth-client) for context.

Please ignore the requests/django integration at the moment, as I've only focused on HTTPX in FastAPI at the moment. I'll update the other integrations once the approach is more finalized.

To use in Client:
* A dev would instantiate a rfc9449.DPoPProof, and pass that to the OAuthClient.
* The session JWK is created internally, and passed back on the token to be persisted along with the token since it needs to remain the same for the lifespan of the auth session and used for all interactions after /authorize or /par.
* A JWK can also be passed initially if desired, taken off the token that's passed into the client (if available), or have the mechanism to generate the JWK overridden if something besides ES256 is needed.
* TokenAuth/ClientAuth support retrying the request when a new nonce is returned from the auth/resource servers.

I explored refactoring TokenAuth/ClientAuth to support multiple Auths (separating Authorization header/client_secret_* modifications, and the DPoP proof header modifications), but that turned out to be more complicated than I originally expected. This would've introduced a new CompositeAuth to handle the pairs: TokenAuth/DPoPAuth, ClientAuth/DPoPAuth. I'm not against further exploring this idea, if it's desired by the maintainers. For now, I've implemented DPoP Proof directly in TokenAuth/ClientAuth implementations.

To use in Server:
```
dpop_nonce_generator = DefaultDPoPNonceGenerator()
dpop_proof_validator = DPoPProofValidator(nonce_generator=dpop_nonce_generator)
dpop_extension = DPoP(proof_validator=dpop_proof_validator)
server.register_grant(MyAuthorizationCodeGrant, [dpop_extension])
server.register_grant(MyRefreshTokenGrant, [dpop_extension])

require_oauth = ResourceProtector()
require_oauth.register_token_validator(MyDPoPTokenValidator(proof_validator=dpop_proof_validator))
```

Feel free to give any comments or ask questions as necessary about the implementation. Once I've got go ahead for the approach I'll clean up, implement the further integrations, add tests, and put up a final PR.

Thanks!

TODO:
* [ ] Other integrations
* [ ] Tests
* [x] Code in proper rfc* locations
* [x] An authorization server MAY elect to issue access tokens that are not DPoP bound, which is signaled to the client with a value of Bearer in the token_type parameter of the access token response per [RFC6750]. For a public client that is also issued a refresh token, this has the effect of DPoP-binding the refresh token alone, which can improve the security posture even when protected resources are not updated to support DPoP.
* [x] Add `dpop_signing_alg_values_supported` to metadata, and check alg against it
* [x] dpop_jkt parameter
* [x] server support (validate proofs, generate nonces, appropriate errors)
* [ ] Add nonce timestamp checking to proof iat checking 