### PR TITLE
Fix `InsecureTransportError` raising

### DIFF
--- a/authlib/oauth2/rfc6749/authorization_server.py
+++ b/authlib/oauth2/rfc6749/authorization_server.py
@@ -251,8 +251,9 @@ class AuthorizationServer(Hookable):
         """Validate current HTTP request for authorization page. This page
         is designed for resource owner to grant or deny the authorization.
         """
+        request = self.create_oauth2_request(request)
+
         try:
-            request = self.create_oauth2_request(request)
             request.user = end_user
 
             grant = self.get_authorization_grant(request)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.6.4
+-------------
+
+**Unreleased**
+
+- Fix ``InsecureTransportError`` error raising. :issue:`795`
+
 Version 1.6.3
 -------------
 

--- a/tests/django/test_oauth2/oauth2_server.py
+++ b/tests/django/test_oauth2/oauth2_server.py
@@ -17,7 +17,7 @@ class TestCase(_TestCase):
 
     def tearDown(self):
         super().tearDown()
-        os.environ.pop("AUTHLIB_INSECURE_TRANSPORT")
+        os.environ.pop("AUTHLIB_INSECURE_TRANSPORT", None)
 
     def create_server(self):
         return AuthorizationServer(Client, OAuth2Token)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

There was an issue with InsecureTransportError being raised while the request has not fully been initialized by Django/Flask. Then the authorization server would try to catch the exception and enrich with request.payload.state, that don't exist because the request is not initialized.

The fix is to avoid enriching the 'state' parameter for exceptions raised during the request initialization, that for the moment can only be InsecureTransportError.

fixes #795 

**Checklist**

- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
