### PR TITLE
RFC-9126: PAR

### DIFF
--- a/authlib/integrations/base_client/async_app.py
+++ b/authlib/integrations/base_client/async_app.py
@@ -1,6 +1,8 @@
 import logging
 import time
 
+from authlib.common.security import generate_token
+
 from authlib.common.urls import urlparse
 
 from .errors import MissingRequestTokenError
@@ -90,28 +92,59 @@ class AsyncOAuth2Mixin(OAuth2Base):
         async with self._get_oauth_client(**metadata) as session:
             return await _http_request(self, session, method, url, token, kwargs)
 
-    async def create_authorization_url(self, redirect_uri=None, **kwargs):
+    async def create_authorization_url(self, redirect_uri=None, authorize_url_params=None, **authorize_params):
         """Generate the authorization url and state for HTTP redirect.
 
         :param redirect_uri: Callback or redirect URI for authorization.
-        :param kwargs: Extra parameters to include.
+        :param authorize_url_params: Extra parameters specifically for the authorize_url endpoint, regardless of method.
+        :param authorize_params: Extra parameters to include for authorization.
         :return: dict
         """
         metadata = await self.load_server_metadata()
+        if self.authorize_params:
+            authorize_params.update(self.authorize_params)
+
+        authorize_url_params = authorize_url_params or {}
+        if self.authorize_url_params:
+            authorize_url_params.update(self.authorize_url_params)
+
         authorization_endpoint = self.authorize_url or metadata.get(
             "authorization_endpoint"
         )
         if not authorization_endpoint:
             raise RuntimeError('Missing "authorize_url" value')
 
-        if self.authorize_params:
-            kwargs.update(self.authorize_params)
+        par_endpoint = self.pushed_authorization_url or metadata.get(
+            "pushed_authorization_request_endpoint"
+        )
+        par_required = metadata.get("require_pushed_authorization_requests")
+        if par_required and not par_endpoint:
+            raise RuntimeError('Missing "pushed_authorization_url" value')
 
         async with self._get_oauth_client(**metadata) as client:
-            client.redirect_uri = redirect_uri
-            return self._create_oauth2_authorization_url(
-                client, authorization_endpoint, **kwargs
-            )
+            if redirect_uri is not None:
+                client.redirect_uri = redirect_uri
+
+            if par_required:
+                rv, request_uri = await self._pushed_authorization_request(client, par_endpoint, **authorize_params)
+                url, _ = client.create_authorization_url(
+                    authorization_endpoint,
+                    request_uri=request_uri['request_uri'],
+                    **authorize_url_params)
+                rv['url'] = url
+                return rv
+            else:
+                authorize_params.update(authorize_url_params)
+                return self._create_oauth2_authorization_url(client, authorization_endpoint, **authorize_params)
+
+    async def _pushed_authorization_request(self, client, par_endpoint, **kwargs):
+        rv = {}
+        params = self._get_authorization_params(client, **kwargs)
+        rv.update(params)
+        kwargs.update(params)
+        request_uri, state = await client.pushed_authorization(par_endpoint, **kwargs)
+        rv["state"] = state
+        return rv, request_uri
 
     async def fetch_access_token(self, redirect_uri=None, **kwargs):
         """Fetch access token in the final step.

--- a/authlib/integrations/base_client/async_app.py
+++ b/authlib/integrations/base_client/async_app.py
@@ -120,6 +120,7 @@ class AsyncOAuth2Mixin(OAuth2Base):
         par_required = metadata.get("require_pushed_authorization_requests")
         if par_required and not par_endpoint:
             raise RuntimeError('Missing "pushed_authorization_url" value')
+        par_required = par_required or par_endpoint
 
         async with self._get_oauth_client(**metadata) as client:
             if redirect_uri is not None:

--- a/authlib/integrations/base_client/registry.py
+++ b/authlib/integrations/base_client/registry.py
@@ -16,6 +16,8 @@ OAUTH_CLIENT_PARAMS = (
     "refresh_token_params",
     "authorize_url",
     "authorize_params",
+    "authorize_url_params",
+    "pushed_authorization_url",
     "api_base_url",
     "client_kwargs",
     "server_metadata_url",

--- a/authlib/integrations/base_client/sync_app.py
+++ b/authlib/integrations/base_client/sync_app.py
@@ -370,6 +370,7 @@ class OAuth2Mixin(_RequestMixin, OAuth2Base):
         par_required = metadata.get("require_pushed_authorization_requests")
         if par_required and not par_endpoint:
             raise RuntimeError('Missing "pushed_authorization_url" value')
+        par_required = par_required or par_endpoint
 
         with self._get_oauth_client(**metadata) as client:
             if redirect_uri is not None:

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -200,6 +200,18 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
 
         return self.token
 
+    async def _pushed_authorization(
+        self, url, state, body="", headers=None, auth=None, **kwargs
+    ):
+        resp = await self.post(
+            url, data=dict(url_decode(body)), headers=headers, auth=auth, **kwargs
+        )
+
+        for hook in self.compliance_hook["pushed_authorization_response"]:
+            resp = hook(resp)
+
+        return self.parse_response_request_uri(resp), state
+
     def _http_post(
         self, url, body=None, auth=USE_CLIENT_DEFAULT, headers=None, **kwargs
     ):

--- a/authlib/integrations/starlette_client/apps.py
+++ b/authlib/integrations/starlette_client/apps.py
@@ -22,18 +22,19 @@ class StarletteAppMixin:
         else:
             raise RuntimeError("Missing state value")
 
-    async def authorize_redirect(self, request, redirect_uri=None, **kwargs):
+    async def authorize_redirect(self, request, redirect_uri=None, authorize_url_params=None, **kwargs):
         """Create a HTTP Redirect for Authorization Endpoint.
 
         :param request: HTTP request instance from Starlette view.
         :param redirect_uri: Callback or redirect URI for authorization.
-        :param kwargs: Extra parameters to include.
+        :param authorize_url_params: Extra parameters specifically for the authorize_url endpoint, regardless of method.
+        :param kwargs: Extra parameters to include for authorization.
         :return: A HTTP redirect response.
         """
         # Handle Starlette >= 0.26.0 where redirect_uri may now be a URL and not a string
         if redirect_uri and isinstance(redirect_uri, URL):
             redirect_uri = str(redirect_uri)
-        rv = await self.create_authorization_url(redirect_uri, **kwargs)
+        rv = await self.create_authorization_url(redirect_uri, authorize_url_params, **kwargs)
         await self.save_authorize_data(request, redirect_uri=redirect_uri, **rv)
         return RedirectResponse(rv["url"], status_code=302)
 

--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -1,15 +1,17 @@
 from authlib.common.security import generate_token
-from authlib.common.urls import url_decode
+from authlib.common.urls import add_params_to_qs, add_params_to_uri, url_decode
 
 from .auth import ClientAuth
 from .auth import TokenAuth
 from .base import OAuth2Error
+from .rfc6749 import InvalidRequestError
 from .rfc6749.parameters import parse_authorization_code_response
 from .rfc6749.parameters import parse_implicit_response
-from .rfc6749.parameters import prepare_grant_uri
+from .rfc6749.parameters import prepare_grant_params
 from .rfc6749.parameters import prepare_token_request
 from .rfc7009 import prepare_revoke_token_request
 from .rfc7636 import create_s256_code_challenge
+from .rfc9126.parameters import prepare_grant_uri
 
 DEFAULT_HEADERS = {
     "Accept": "application/json",
@@ -107,6 +109,8 @@ class OAuth2Client:
             "access_token_response": set(),
             "refresh_token_request": set(),
             "refresh_token_response": set(),
+            "pushed_authorization_request": set(),
+            "pushed_authorization_response": set(),
             "revoke_token_request": set(),
             "introspect_token_request": set(),
         }
@@ -141,16 +145,50 @@ class OAuth2Client:
     def token(self, token):
         self.token_auth.set_token(token)
 
-    def create_authorization_url(self, url, state=None, code_verifier=None, **kwargs):
+    def create_authorization_url(self, url, state=None, code_verifier=None, request_uri=None, **kwargs):
         """Generate an authorization URL and state.
 
         :param url: Authorization endpoint url, must be HTTPS.
         :param state: An optional state string for CSRF protection. If not
                       given it will be generated for you.
         :param code_verifier: An optional code_verifier for code challenge.
+        :param request_uri: An optional request_uri for PAR
         :param kwargs: Extra parameters to include.
         :return: authorization_url, state
         """
+        if request_uri:
+            uri = prepare_grant_uri(url, client_id=self.client_id, request_uri=request_uri, **kwargs)
+            return uri, state
+
+        params, state = self._prepare_authorization_params(state=state, code_verifier=code_verifier, **kwargs)
+        uri = add_params_to_uri(url, params)
+        return uri, state
+
+    def pushed_authorization(self, url=None, body="", headers=None, auth=None, state=None, code_verifier=None, **kwargs):
+        if "request_uri" in kwargs:
+            raise InvalidRequestError("request_uri MUST NOT be present in the push authorization request.")
+
+        session_kwargs = self._extract_session_request_params(kwargs)
+        params, state = self._prepare_authorization_params(state=state, code_verifier=code_verifier, **kwargs)
+        body = add_params_to_qs(body, params)
+
+        if auth is None:
+            auth = self.client_auth(self.token_endpoint_auth_method)
+
+        if headers is None:
+            headers = DEFAULT_HEADERS
+
+        if url is None:
+            url = self.metadata.get("pushed_authorization_request_endpoint")
+
+        for hook in self.compliance_hook["pushed_authorization_request"]:
+            url, headers, body = hook(url, headers, body)
+
+        return self._pushed_authorization(
+            url, state, body=body, auth=auth, headers=headers, **session_kwargs
+        )
+
+    def _prepare_authorization_params(self, state=None, code_verifier=None, **kwargs):
         if state is None:
             state = generate_token()
 
@@ -173,14 +211,13 @@ class OAuth2Client:
             if k not in kwargs and k in self.metadata:
                 kwargs[k] = self.metadata[k]
 
-        uri = prepare_grant_uri(
-            url,
+        params = prepare_grant_params(
             client_id=self.client_id,
             response_type=response_type,
             state=state,
             **kwargs,
         )
-        return uri, state
+        return params, state
 
     def fetch_token(
         self,
@@ -397,6 +434,8 @@ class OAuth2Client:
         * access_token_response: invoked before token parsing.
         * refresh_token_request: invoked before refreshing token.
         * refresh_token_response: invoked before refresh token parsing.
+        * pushed_authorization_request: invoked before push authorization request.
+        * pushed_authorization_response: invoked before push authorization request request_uri parsing.
         * protected_request: invoked before making a request.
         * revoke_token_request: invoked before revoking a token.
         * introspect_token_request: invoked before introspecting a token.
@@ -410,6 +449,17 @@ class OAuth2Client:
                 "Hook type %s is not in %s.", hook_type, self.compliance_hook
             )
         self.compliance_hook[hook_type].add(hook)
+
+    def parse_response_request_uri(self, resp):
+        if resp.status_code >= 500:
+            resp.raise_for_status()
+
+        request_uri = resp.json()
+        if "error" in request_uri:
+            raise self.oauth_error_class(
+                error=request_uri["error"], description=request_uri.get("error_description")
+            )
+        return request_uri
 
     def parse_response_token(self, resp):
         if resp.status_code >= 500:
@@ -460,6 +510,16 @@ class OAuth2Client:
             self.update_token(self.token, refresh_token=refresh_token)
 
         return self.token
+
+    def _pushed_authorization(
+        self, url, state, body="", headers=None, auth=None, **kwargs
+    ):
+        resp = self._http_post(url, body=body, auth=auth, headers=headers, **kwargs)
+
+        for hook in self.compliance_hook["pushed_authorization_response"]:
+            resp = hook(resp)
+
+        return self.parse_response_request_uri(resp), state
 
     def _handle_token_hint(
         self,

--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -166,7 +166,7 @@ class OAuth2Client:
 
     def pushed_authorization(self, url=None, body="", headers=None, auth=None, state=None, code_verifier=None, **kwargs):
         if "request_uri" in kwargs:
-            raise InvalidRequestError("request_uri MUST NOT be present in the push authorization request.")
+            raise InvalidRequestError("The 'request_uri' parameter MUST NOT be present in the pushed authorization request.")
 
         session_kwargs = self._extract_session_request_params(kwargs)
         params, state = self._prepare_authorization_params(state=state, code_verifier=code_verifier, **kwargs)

--- a/authlib/oauth2/rfc6749/grants/authorization_code.py
+++ b/authlib/oauth2/rfc6749/grants/authorization_code.py
@@ -1,4 +1,7 @@
 import logging
+from typing import Tuple
+
+from authlib.consts import default_json_headers
 
 from authlib.common.security import generate_token
 from authlib.common.urls import add_params_to_uri
@@ -10,14 +13,14 @@ from ..errors import InvalidRequestError
 from ..errors import OAuth2Error
 from ..errors import UnauthorizedClientError
 from ..hooks import hooked
-from .base import AuthorizationEndpointMixin
+from .base import AuthorizationEndpointMixin, PushedAuthorizationEndpointMixin
 from .base import BaseGrant
 from .base import TokenEndpointMixin
 
 log = logging.getLogger(__name__)
 
 
-class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpointMixin):
+class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, PushedAuthorizationEndpointMixin, TokenEndpointMixin):
     """The authorization code grant type is used to obtain both access
     tokens and refresh tokens and is optimized for confidential clients.
     Since this is a redirection-based flow, the client must be capable of
@@ -57,6 +60,12 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
 
     #: Generated "code" length
     AUTHORIZATION_CODE_LENGTH = 48
+
+    #: Generated "request_uri" length
+    REQUEST_URI_LENGTH = 48
+    REQUEST_URI_EXPIRES_IN = 60  # 1 minute
+
+    REQUIRE_PUSHED_AUTHORIZATION_REQUESTS = False
 
     RESPONSE_TYPES = {"code"}
     GRANT_TYPE = "authorization_code"
@@ -150,20 +159,64 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
             resource owner, otherwise pass None.
         :returns: (status_code, body, headers)
         """
+        if self.request.payload.request_uri:
+            code, state = self._get_authorization_code_by_request_uri(self.request.payload.request_uri)
+        else:
+            if self.REQUIRE_PUSHED_AUTHORIZATION_REQUESTS:
+                raise InvalidRequestError(description="Pushed authorization request required before authorizing user")
+            code, state = self._create_authorization_code(grant_user, redirect_uri)
+
+        params = [("code", code)]
+        if state:
+            params.append(("state", state))
+        uri = add_params_to_uri(redirect_uri, params)
+        headers = [("Location", uri)]
+        return 302, "", headers
+
+    def validate_pushed_authorization_request(self):
+        client = self.authenticate_token_endpoint_client()
+        log.debug("Validate PAR request of %r", client)
+        if not client.check_grant_type(self.GRANT_TYPE):
+            raise UnauthorizedClientError(
+                f"The client is not authorized to use 'grant_type={self.GRANT_TYPE}'"
+            )
+
+        if self.request.payload.request_uri:
+            raise InvalidRequestError("The 'request_uri' parameter MUST NOT be present in the pushed authorization request.")
+        return validate_code_authorization_request(self)
+
+    def create_pushed_authorization_response(self, redirect_uri: str, grant_user):
+        request_uri, expires_in = self.generate_request_uri()
+        self._create_authorization_code(grant_user, redirect_uri, request_uri, expires_in)
+        request_uri = {
+            "request_uri": request_uri,
+            "expires_in": expires_in
+        }
+        return 201, request_uri, default_json_headers
+
+    def _get_authorization_code_by_request_uri(self, request_uri):
+        request = self.request
+        authorization_code = self.query_authorization_code_by_request_uri(request_uri, request.client)
+        if not authorization_code:
+            raise InvalidGrantError("Invalid 'request_uri' in request.")
+        if authorization_code.is_request_uri_expired():
+            self.delete_authorization_code(authorization_code)
+            raise InvalidGrantError("'request_uri' is expired")
+        authorization_code.remove_request_uri()
+        self.update_authorization_code(authorization_code)
+        code = authorization_code.get_code()
+        state = authorization_code.get_state()
+        return code, state
+
+    def _create_authorization_code(self, grant_user, redirect_uri, request_uri=None, expires_in=None):
         if not grant_user:
             raise AccessDeniedError(redirect_uri=redirect_uri)
 
         self.request.user = grant_user
-
+        state = self.request.payload.state
         code = self.generate_authorization_code()
-        self.save_authorization_code(code, self.request)
-
-        params = [("code", code)]
-        if self.request.payload.state:
-            params.append(("state", self.request.payload.state))
-        uri = add_params_to_uri(redirect_uri, params)
-        headers = [("Location", uri)]
-        return 302, "", headers
+        self.save_authorization_code(code, self.request, state=state, request_uri=request_uri, request_uri_expires_in=expires_in)
+        return code, state
 
     @hooked
     def validate_token_request(self):
@@ -290,7 +343,7 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
         return 200, token, self.TOKEN_RESPONSE_HEADER
 
     def generate_authorization_code(self):
-        """ "The method to generate "code" value for authorization code data.
+        """The method to generate "code" value for authorization code data.
         Developers may rewrite this method, or customize the code length with::
 
             class MyAuthorizationCodeGrant(AuthorizationCodeGrant):
@@ -298,7 +351,19 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
         """
         return generate_token(self.AUTHORIZATION_CODE_LENGTH)
 
-    def save_authorization_code(self, code, request):
+    def generate_request_uri(self) -> Tuple[str, int]:
+        """The method to generate "request_uri" value for authorization code data
+         for Pushed Authorization Requests.
+
+        Developers may rewrite this method, or customize the code length with::
+
+            class MyAuthorizationCodeGrant(AuthorizationCodeGrant):
+                REQUEST_URI_LENGTH = 32  # default is 48
+        """
+        return (f"urn:ietf:params:oauth:request_uri:{generate_token(self.REQUEST_URI_LENGTH)}",
+                self.REQUEST_URI_EXPIRES_IN)
+
+    def save_authorization_code(self, code, request, state=None, request_uri=None, request_uri_expires_in=None):
         """Save authorization_code for later use. Developers MUST implement
         it in subclass. Here is an example::
 
@@ -315,6 +380,26 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
         """
         raise NotImplementedError()
 
+    def save_authorization_code_v2(self, request, code, state=None, request_uri=None, request_uri_expires_in=None):
+        """Save authorization_code for later use. Developers MUST implement
+        it in subclass. Here is an example::
+
+            def save_authorization_code(self, code, request):
+                client = request.client
+                item = AuthorizationCode(
+                    code=code,
+                    client_id=client.client_id,
+                    redirect_uri=request.payload.redirect_uri,
+                    scope=request.payload.scope,
+                    user_id=request.user.id,
+                    state=state,
+                    request_uri=request_uri,
+                    request_uri_expires_in=request_uri_expires_in,
+                )
+                item.save()
+        """
+        raise NotImplementedError()
+
     def query_authorization_code(self, code, client):  # pragma: no cover
         """Get authorization_code from previously savings. Developers MUST
         implement it in subclass::
@@ -322,10 +407,43 @@ class AuthorizationCodeGrant(BaseGrant, AuthorizationEndpointMixin, TokenEndpoin
             def query_authorization_code(self, code, client):
                 return Authorization.get(code=code, client_id=client.client_id)
 
-        :param code: a string represent the code.
+        :param code: the code.
         :param client: client related to this code.
         :return: authorization_code object
         """
+        raise NotImplementedError()
+
+    def query_authorization_code_by_request_uri(self, request_uri, client):  # pragma: no cover
+        """Get authorization_code from previously savings. Developers MUST
+        implement it in subclass::
+
+            def query_authorization_code(self, request_uri, client):
+                return Authorization.get(request_uri=request_uri, client_id=client.client_id)
+
+        :param request_uri: the request_uri from a PAR request.
+        :param client: client related to this code.
+        :return: authorization_code object
+        """
+        raise NotImplementedError()
+
+    def query_authorization_code_v2(self, client, code=None, request_uri=None):
+        """Get authorization_code from previously savings. Developers MUST
+        implement it in subclass::
+
+            def query_authorization_code(self, client, code=None, request_uri=None):
+                if code:
+                    return Authorization.get(code=code, client_id=client.client_id)
+                elif request_uri:
+                    return Authorization.get(request_uri=request_uri, client_id=client.client_id)
+
+        :param client: client related to this code.
+        :param code: the code.
+        :param request_uri: the request_uri from a PAR request.
+        :return: authorization_code object
+        """
+        raise NotImplementedError()
+
+    def update_authorization_code(self, authorization_code):
         raise NotImplementedError()
 
     def delete_authorization_code(self, authorization_code):

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -112,7 +112,7 @@ class AuthorizationEndpointMixin:
 
     @classmethod
     def check_authorization_endpoint(cls, request: OAuth2Request):
-        return request.payload.response_type in cls.RESPONSE_TYPES or request.payload.request_uri
+        return request.payload.response_type in cls.RESPONSE_TYPES
 
     @staticmethod
     def validate_authorization_redirect_uri(request: OAuth2Request, client):
@@ -155,12 +155,4 @@ class AuthorizationEndpointMixin:
         raise NotImplementedError()
 
     def create_authorization_response(self, redirect_uri: str, grant_user):
-        raise NotImplementedError()
-
-
-class PushedAuthorizationEndpointMixin:
-    def validate_pushed_authorization_request(self):
-        raise NotImplementedError()
-
-    def create_pushed_authorization_response(self, redirect_uri: str, grant_user):
         raise NotImplementedError()

--- a/authlib/oauth2/rfc6749/grants/base.py
+++ b/authlib/oauth2/rfc6749/grants/base.py
@@ -112,7 +112,7 @@ class AuthorizationEndpointMixin:
 
     @classmethod
     def check_authorization_endpoint(cls, request: OAuth2Request):
-        return request.payload.response_type in cls.RESPONSE_TYPES
+        return request.payload.response_type in cls.RESPONSE_TYPES or request.payload.request_uri
 
     @staticmethod
     def validate_authorization_redirect_uri(request: OAuth2Request, client):
@@ -155,4 +155,12 @@ class AuthorizationEndpointMixin:
         raise NotImplementedError()
 
     def create_authorization_response(self, redirect_uri: str, grant_user):
+        raise NotImplementedError()
+
+
+class PushedAuthorizationEndpointMixin:
+    def validate_pushed_authorization_request(self):
+        raise NotImplementedError()
+
+    def create_pushed_authorization_response(self, redirect_uri: str, grant_user):
         raise NotImplementedError()

--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -165,30 +165,6 @@ class AuthorizationCodeMixin:
         """
         raise NotImplementedError()
 
-    def get_code(self):
-        raise NotImplementedError()
-
-    def get_state(self):
-        raise NotImplementedError()
-
-    def get_request_uri_expires_in(self):
-        raise NotImplementedError()
-
-    def is_request_uri_expired(self):
-        """A method to define if this token is expired. For instance,
-        there is a column ``request_uri_expired_at`` in the table::
-
-            def is_request_uri_expired(self):
-                return self.request_uri_expired_at < now
-
-        :return: boolean
-        """
-        raise NotImplementedError()
-
-    def remove_request_uri(self):
-        raise NotImplementedError()
-
-
 
 class TokenMixin:
     def check_client(self, client):

--- a/authlib/oauth2/rfc6749/models.py
+++ b/authlib/oauth2/rfc6749/models.py
@@ -165,6 +165,30 @@ class AuthorizationCodeMixin:
         """
         raise NotImplementedError()
 
+    def get_code(self):
+        raise NotImplementedError()
+
+    def get_state(self):
+        raise NotImplementedError()
+
+    def get_request_uri_expires_in(self):
+        raise NotImplementedError()
+
+    def is_request_uri_expired(self):
+        """A method to define if this token is expired. For instance,
+        there is a column ``request_uri_expired_at`` in the table::
+
+            def is_request_uri_expired(self):
+                return self.request_uri_expired_at < now
+
+        :return: boolean
+        """
+        raise NotImplementedError()
+
+    def remove_request_uri(self):
+        raise NotImplementedError()
+
+
 
 class TokenMixin:
     def check_client(self, client):

--- a/authlib/oauth2/rfc6749/parameters.py
+++ b/authlib/oauth2/rfc6749/parameters.py
@@ -45,6 +45,16 @@ def prepare_grant_uri(
     .. _`Section 3.3`: https://tools.ietf.org/html/rfc6749#section-3.3
     .. _`section 10.12`: https://tools.ietf.org/html/rfc6749#section-10.12
     """
+    params = prepare_grant_params(client_id, response_type, redirect_uri, scope, state, **kwargs)
+    return add_params_to_uri(uri, params)
+
+
+def prepare_grant_request(client_id, response_type, body="", redirect_uri=None, scope=None, state=None, **kwargs):
+    params = prepare_grant_params(client_id, response_type, redirect_uri, scope, state, **kwargs)
+    return add_params_to_qs(body, params)
+
+
+def prepare_grant_params(client_id, response_type, redirect_uri=None, scope=None, state=None, **kwargs):
     params = [("response_type", response_type), ("client_id", client_id)]
 
     if redirect_uri:
@@ -57,8 +67,7 @@ def prepare_grant_uri(
     for k in kwargs:
         if kwargs[k] is not None:
             params.append((to_unicode(k), kwargs[k]))
-
-    return add_params_to_uri(uri, params)
+    return params
 
 
 def prepare_token_request(grant_type, body="", redirect_uri=None, **kwargs):

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -49,6 +49,10 @@ class OAuth2Payload:
     def state(self):
         return self.data.get("state")
 
+    @property
+    def request_uri(self):
+        return self.data.get("request_uri")
+
 
 class BasicOAuth2Payload(OAuth2Payload):
     def __init__(self, payload):

--- a/authlib/oauth2/rfc6749/requests.py
+++ b/authlib/oauth2/rfc6749/requests.py
@@ -49,10 +49,6 @@ class OAuth2Payload:
     def state(self):
         return self.data.get("state")
 
-    @property
-    def request_uri(self):
-        return self.data.get("request_uri")
-
 
 class BasicOAuth2Payload(OAuth2Payload):
     def __init__(self, payload):
@@ -94,6 +90,8 @@ class OAuth2Request(OAuth2Payload):
         self.authorization_code = None
         self.refresh_token = None
         self.credential = None
+        self.endpoint = None
+        self.source = None
 
     @property
     def args(self):

--- a/authlib/oauth2/rfc8414/models.py
+++ b/authlib/oauth2/rfc8414/models.py
@@ -33,8 +33,6 @@ class AuthorizationServerMetadata(dict):
         "introspection_endpoint_auth_methods_supported",
         "introspection_endpoint_auth_signing_alg_values_supported",
         "code_challenge_methods_supported",
-        "pushed_authorization_request_endpoint",
-        "require_pushed_authorization_requests",
     ]
 
     def validate_issuer(self):
@@ -319,26 +317,6 @@ class AuthorizationServerMetadata(dict):
         """
         validate_array_value(self, "code_challenge_methods_supported")
 
-    def validate_pushed_authorization_request_endpoint(self):
-        """The URL of the pushed authorization request endpoint at which a
-        client can post an authorization request to exchange for a
-        request_uri value usable at the authorization server.
-        """
-        url = self.get("pushed_authorization_request_endpoint")
-        if url and not is_secure_transport(url):
-            raise ValueError('"pushed_authorization_request_endpoint" MUST use "https" scheme')
-
-        require_pushed_authorization_requests = self.require_pushed_authorization_requests
-        if require_pushed_authorization_requests and not url:
-            raise ValueError('"pushed_authorization_request_endpoint" is required')
-
-    def validate_require_pushed_authorization_requests(self):
-        """Boolean parameter indicating whether the authorization server
-        accepts authorization request data only via PAR. If omitted, the
-        default value is false.
-        """
-        _validate_boolean_value(self, "require_pushed_authorization_requests")
-
     @property
     def response_modes_supported(self):
         #: If omitted, the default is ["query", "fragment"]
@@ -371,11 +349,6 @@ class AuthorizationServerMetadata(dict):
         return self.get(
             "introspection_endpoint_auth_methods_supported", ["client_secret_basic"]
         )
-
-    @property
-    def require_pushed_authorization_requests(self):
-        # If omitted, the default value is false.
-        return self.get("require_pushed_authorization_requests", False)
 
     def validate(self):
         """Validate all server metadata value."""

--- a/authlib/oauth2/rfc8414/models.py
+++ b/authlib/oauth2/rfc8414/models.py
@@ -33,6 +33,8 @@ class AuthorizationServerMetadata(dict):
         "introspection_endpoint_auth_methods_supported",
         "introspection_endpoint_auth_signing_alg_values_supported",
         "code_challenge_methods_supported",
+        "pushed_authorization_request_endpoint",
+        "require_pushed_authorization_requests",
     ]
 
     def validate_issuer(self):
@@ -317,6 +319,26 @@ class AuthorizationServerMetadata(dict):
         """
         validate_array_value(self, "code_challenge_methods_supported")
 
+    def validate_pushed_authorization_request_endpoint(self):
+        """The URL of the pushed authorization request endpoint at which a
+        client can post an authorization request to exchange for a
+        request_uri value usable at the authorization server.
+        """
+        url = self.get("pushed_authorization_request_endpoint")
+        if url and not is_secure_transport(url):
+            raise ValueError('"pushed_authorization_request_endpoint" MUST use "https" scheme')
+
+        require_pushed_authorization_requests = self.require_pushed_authorization_requests
+        if require_pushed_authorization_requests and not url:
+            raise ValueError('"pushed_authorization_request_endpoint" is required')
+
+    def validate_require_pushed_authorization_requests(self):
+        """Boolean parameter indicating whether the authorization server
+        accepts authorization request data only via PAR. If omitted, the
+        default value is false.
+        """
+        _validate_boolean_value(self, "require_pushed_authorization_requests")
+
     @property
     def response_modes_supported(self):
         #: If omitted, the default is ["query", "fragment"]
@@ -349,6 +371,11 @@ class AuthorizationServerMetadata(dict):
         return self.get(
             "introspection_endpoint_auth_methods_supported", ["client_secret_basic"]
         )
+
+    @property
+    def require_pushed_authorization_requests(self):
+        # If omitted, the default value is false.
+        return self.get("require_pushed_authorization_requests", False)
 
     def validate(self):
         """Validate all server metadata value."""
@@ -383,3 +410,10 @@ def validate_array_value(metadata, key):
     values = metadata.get(key)
     if values is not None and not isinstance(values, list):
         raise ValueError(f'"{key}" MUST be JSON array')
+
+
+def _validate_boolean_value(metadata, key):
+    if key not in metadata:
+        return
+    if metadata[key] not in (True, False):
+        raise ValueError(f'"{key}" MUST be boolean')

--- a/authlib/oauth2/rfc9101/__init__.py
+++ b/authlib/oauth2/rfc9101/__init__.py
@@ -1,9 +1,11 @@
 from .authorization_server import JWTAuthenticationRequest
+from .authorization_server import JWTAuthorizationRequest
 from .discovery import AuthorizationServerMetadata
 from .registration import ClientMetadataClaims
 
 __all__ = [
     "AuthorizationServerMetadata",
+    "JWTAuthorizationRequest",
     "JWTAuthenticationRequest",
     "ClientMetadataClaims",
 ]

--- a/authlib/oauth2/rfc9101/authorization_server.py
+++ b/authlib/oauth2/rfc9101/authorization_server.py
@@ -1,16 +1,322 @@
+from abc import ABC
+from typing import Any
+from typing import Optional
+
+from authlib.deprecate import deprecate
 from authlib.jose import jwt
 from authlib.jose.errors import JoseError
-
+from .discovery import AuthorizationServerMetadata
+from .errors import InvalidRequestObjectError
+from .errors import InvalidRequestUriError
+from .errors import RequestNotSupportedError
+from .errors import RequestUriNotSupportedError
+from .registration import ClientMetadataClaims
 from ..rfc6749 import AuthorizationServer
 from ..rfc6749 import ClientMixin
 from ..rfc6749 import InvalidRequestError
 from ..rfc6749.authenticate_client import _validate_client
 from ..rfc6749.requests import BasicOAuth2Payload
 from ..rfc6749.requests import OAuth2Request
-from .errors import InvalidRequestObjectError
-from .errors import InvalidRequestUriError
-from .errors import RequestNotSupportedError
-from .errors import RequestUriNotSupportedError
+
+
+class RequestURIExtension:
+    def __init__(self):
+        self._handlers: list['RequestURIHandler'] = []
+
+    def __call__(self, server: AuthorizationServer):
+        server.register_hook(
+            "before_get_authorization_grant", self.handle_request_uri
+        )
+
+    def register_handler(self, handler: 'RequestURIHandler'):
+        self._handlers.append(handler)
+
+    def handle_request_uri(self, server: AuthorizationServer, request: OAuth2Request):
+        if "request_uri" not in request.payload.data or len(self._handlers) == 0:
+            return
+
+        for handler in self._handlers:
+            request_uri_data = handler.get_request_uri_data(request)
+            if request_uri_data:
+                handler.handle_request_uri_data(request_uri_data, server, request)
+                return
+        raise InvalidRequestUriError(state=request.payload.state)
+
+
+class RequestURIHandler(ABC):
+    REQUEST_URI_EXTENSION = RequestURIExtension()
+
+    def __call__(self, server: AuthorizationServer):
+        server.register_extension(self.REQUEST_URI_EXTENSION)
+
+    def get_request_uri_data(self, request: OAuth2Request) -> Any:
+        ...
+
+    def handle_request_uri_data(self, request_uri_data: Any, server: AuthorizationServer, request: OAuth2Request):
+        ...
+
+
+class JWTAuthorizationRequest(RequestURIHandler):
+    """Authorization server extension implementing the support
+    for JWT secured authentication request, as defined in :rfc:`RFC9101 <9101>`.
+
+    :param support_request: Whether to enable support for the ``request`` parameter.
+    :param support_request_uri: Whether to enable support for the ``request_uri`` parameter.
+
+    This extension is intended to be inherited and registered into the authorization server::
+
+        class JWTAuthorizationRequest(rfc9101.JWTAuthorizationRequest):
+            def resolve_client_public_key(self, client: ClientMixin):
+                return get_jwks_for_client(client)
+
+            def get_request_object(self, request_uri: str):
+                try:
+                    return requests.get(request_uri).text
+                except requests.Exception:
+                    return None
+
+            def get_server_metadata(self):
+                return AuthorizationServerMetadata({
+                    "issuer": ...,
+                    "authorization_endpoint": ...,
+                    "require_signed_request_object": ...,
+                })
+
+            def get_client_metadata(self):
+                return ClientMetadataClaims({
+                    "require_signed_request_object": ...,
+                })
+
+        authorization_server.register_extension(JWTAuthorizationRequest())
+    """
+
+    def __init__(self, support_request: bool = True, support_request_uri: bool = True):
+        self.support_request = support_request
+        self.support_request_uri = support_request_uri
+
+    def __call__(self, authorization_server: AuthorizationServer):
+        super().__call__(authorization_server)
+        if self.support_request_uri:
+            self.REQUEST_URI_EXTENSION.register_handler(self)
+        if self.support_request:
+            authorization_server.register_hook(
+                "before_get_authorization_grant", self.handle_request_data
+            )
+
+    def get_request_uri_data(self, request: OAuth2Request) -> Optional[str]:
+        if not self._should_proceed_with_request_uri_parameter(request):
+            return None
+        return self._get_raw_request_object(request)
+
+    def handle_request_uri_data(self, request_uri_data: str, server: AuthorizationServer, request: OAuth2Request):
+        self._handle_raw_request_object(request_uri_data, server, request)
+
+    def handle_request_data(self, server: AuthorizationServer, request: OAuth2Request):
+        if not self._should_proceed_with_request_parameter(request):
+            return
+        raw_request_object = self._get_raw_request_object(request)
+        self._handle_raw_request_object(raw_request_object, server, request)
+
+    def _handle_raw_request_object(self, raw_request_object: str, server: AuthorizationServer, request: OAuth2Request):
+        client = _validate_client(server.query_client, request.payload.client_id)
+        self._validate_authorization_request(request, client)
+
+        request_object = self._decode_request_object(request, client, raw_request_object)
+        payload = BasicOAuth2Payload(request_object)
+        request.payload = payload
+        request.source = "jwt_authorization_request"
+
+    def _should_proceed_with_request_uri_parameter(self, request: OAuth2Request):
+        if "request" in request.payload.data and "request_uri" in request.payload.data:
+            raise InvalidRequestError(
+                "The 'request' and 'request_uri' parameters are mutually exclusive.",
+                state=request.payload.state,
+            )
+
+        if "request_uri" in request.payload.data and self.support_request_uri:
+            return True
+
+        return False
+
+    def _should_proceed_with_request_parameter(self, request: OAuth2Request):
+        if "request" in request.payload.data and "request_uri" in request.payload.data:
+            raise InvalidRequestError(
+                "The 'request' and 'request_uri' parameters are mutually exclusive.",
+                state=request.payload.state,
+            )
+
+        if "request" in request.payload.data and self.support_request:
+            return True
+
+        return False
+
+    def _validate_authorization_request(self, request: OAuth2Request, client: ClientMixin):
+        if "request" in request.payload.data and "request_uri" in request.payload.data:
+            raise InvalidRequestError(
+                "The 'request' and 'request_uri' parameters are mutually exclusive.",
+                state=request.payload.state,
+            )
+
+        if "request" in request.payload.data:
+            if not self.support_request:
+                raise RequestNotSupportedError(state=request.payload.state)
+
+        if "request_uri" in request.payload.data:
+            if not self.support_request_uri:
+                raise RequestUriNotSupportedError(state=request.payload.state)
+
+        # When the value of it [require_signed_request_object] as client metadata is true,
+        # then the server MUST reject the authorization request
+        # from the client that does not conform to this specification.
+        client_metadata = self.get_client_metadata(client)
+        if client_metadata.require_signed_request_object:
+            raise InvalidRequestError(
+                "Authorization requests for this client must use signed request objects.",
+                state=request.payload.state,
+            )
+
+        # When the value of it [require_signed_request_object] as server metadata is true,
+        # then the server MUST reject the authorization request
+        # from any client that does not conform to this specification.
+        server_metadata = self.get_server_metadata()
+        if server_metadata and server_metadata.require_signed_request_object:
+            raise InvalidRequestError(
+                "Authorization requests for this server must use signed request objects.",
+                state=request.payload.state,
+            )
+
+    def _get_raw_request_object(self, request: OAuth2Request) -> str:
+        if "request_uri" in request.payload.data:
+            raw_request_object = self.get_request_object(request.payload.data["request_uri"])
+        else:
+            raw_request_object = request.payload.data["request"]
+
+        return raw_request_object
+
+    def _decode_request_object(self, request, client: ClientMixin, raw_request_object: str):
+        jwks = self.resolve_client_public_key(client)
+
+        try:
+            request_object = jwt.decode(raw_request_object, jwks)
+            request_object.validate()
+
+        except JoseError as error:
+            raise InvalidRequestObjectError(
+                description=error.description or InvalidRequestObjectError.description,
+                state=request.payload.state,
+            ) from error
+
+        # It MUST also reject the request if the Request Object uses an
+        # alg value of none when this server metadata value is true.
+        # If omitted, the default value is false.
+        client_metadata = self.get_client_metadata(client)
+        if (
+            client_metadata
+            and client_metadata.require_signed_request_object
+            and request_object.header["alg"] == "none"
+        ):
+            raise InvalidRequestError(
+                "Authorization requests for this client must use signed request objects.",
+                state=request.payload.state,
+            )
+
+        # It MUST also reject the request if the Request Object uses an
+        # alg value of none. If omitted, the default value is false.
+        server_metadata = self.get_server_metadata()
+        if (
+            server_metadata
+            and server_metadata.require_signed_request_object
+            and request_object.header["alg"] == "none"
+        ):
+            raise InvalidRequestError(
+                "Authorization requests for this server must use signed request objects.",
+                state=request.payload.state,
+            )
+
+        # The client ID values in the client_id request parameter and in
+        # the Request Object client_id claim MUST be identical.
+        if request_object["client_id"] != request.payload.client_id:
+            raise InvalidRequestError(
+                "The 'client_id' claim from the request parameters "
+                "and the request object claims don't match.",
+                state=request.payload.state,
+            )
+
+        # The Request Object MAY be sent by value, as described in Section 5.1,
+        # or by reference, as described in Section 5.2. request and
+        # request_uri parameters MUST NOT be included in Request Objects.
+        if "request" in request_object or "request_uri" in request_object:
+            raise InvalidRequestError(
+                "The 'request' and 'request_uri' parameters must not be included in the request object.",
+                state=request.payload.state,
+            )
+
+        return request_object
+
+    def get_request_object(self, request_uri: str) -> Optional[str]:
+        """Download the request object at ``request_uri``.
+
+        This method must be implemented if the ``request_uri`` parameter is supported::
+
+            class JWTAuthorizationRequest(rfc9101.JWTAuthorizationRequest):
+                def get_request_object(self, request_uri: str):
+                    try:
+                        return requests.get(request_uri).text
+                    except requests.Exception:
+                        return None
+        """
+        raise NotImplementedError()
+
+    def resolve_client_public_key(self, client: ClientMixin):
+        """Resolve the client public key for verifying the JWT signature.
+        A client may have many public keys, in this case, we can retrieve it
+        via ``kid`` value in headers. Developers MUST implement this method::
+
+            class JWTAuthorizationRequest(rfc9101.JWTAuthorizationRequest):
+                def resolve_client_public_key(self, client):
+                    if client.jwks_uri:
+                        return requests.get(client.jwks_uri).json
+
+                    return client.jwks
+        """
+        raise NotImplementedError()
+
+    def get_server_metadata(self) -> AuthorizationServerMetadata:
+        """Return server metadata which includes supported grant types,
+        response types and etc.
+
+        When the ``require_signed_request_object`` claim is :data:`True`,
+        all clients require that authorization requests
+        use request objects, and an error will be returned when the authorization
+        request payload is passed in the request body or query string::
+
+            class JWTAuthorizationRequest(rfc9101.JWTAuthorizationRequest):
+                def get_server_metadata(self):
+                    return AuthorizationServerMetadata({
+                        "issuer": ...,
+                        "authorization_endpoint": ...,
+                        "require_signed_request_object": ...,
+                    })
+
+        """
+        return AuthorizationServerMetadata()
+
+    def get_client_metadata(self, client: ClientMixin) -> ClientMetadataClaims:
+        """Return the 'require_signed_request_object' client metadata.
+
+        When :data:`True`, the client requires that authorization requests
+        use request objects, and an error will be returned when the authorization
+        request payload is passed in the request body or query string::
+
+            class JWTAuthorizationRequest(rfc9101.JWTAuthorizationRequest):
+                def get_client_metadata(self):
+                    return ClientMetadataClaims({
+                        "require_signed_request_object": ...,
+                    })
+
+        If not implemented, the value is considered as :data:`False`.
+        """
+        return ClientMetadataClaims()
 
 
 class JWTAuthenticationRequest:
@@ -47,6 +353,10 @@ class JWTAuthenticationRequest:
     """
 
     def __init__(self, support_request: bool = True, support_request_uri: bool = True):
+        deprecate(
+            "'JWTAuthenticationRequest' is deprecated in favor of 'JWTAuthorizationRequest'",
+            version="1.8",
+        )
         self.support_request = support_request
         self.support_request_uri = support_request_uri
 

--- a/authlib/oauth2/rfc9101/discovery.py
+++ b/authlib/oauth2/rfc9101/discovery.py
@@ -5,5 +5,13 @@ class AuthorizationServerMetadata(dict):
     REGISTRY_KEYS = ["require_signed_request_object"]
 
     def validate_require_signed_request_object(self):
-        """Indicates where authorization request needs to be protected as Request Object and provided through either request or request_uri parameter."""
+        """Indicates where authorization request needs to
+        be protected as Request Object and provided through either request
+        or request_uri parameter.
+        """
         _validate_boolean_value(self, "require_signed_request_object")
+
+    @property
+    def require_signed_request_object(self):
+        # If omitted, the default value is false.
+        return self.get("require_signed_request_object", False)

--- a/authlib/oauth2/rfc9126/__init__.py
+++ b/authlib/oauth2/rfc9126/__init__.py
@@ -1,0 +1,13 @@
+from .authorization_server import PushedAuthorizationRequest
+from .discovery import AuthorizationServerMetadata
+from .endpoint import PushedAuthorizationEndpoint
+from .parameters import prepare_grant_uri
+from .registration import ClientMetadataClaims
+
+__all__ = [
+    "prepare_grant_uri",
+    "AuthorizationServerMetadata",
+    "PushedAuthorizationRequest",
+    "PushedAuthorizationEndpoint",
+    "ClientMetadataClaims",
+]

--- a/authlib/oauth2/rfc9126/authorization_server.py
+++ b/authlib/oauth2/rfc9126/authorization_server.py
@@ -1,0 +1,113 @@
+from typing import Optional
+
+from authlib.oauth2.rfc6749 import AuthorizationServer
+from authlib.oauth2.rfc6749 import ClientMixin
+from authlib.oauth2.rfc6749 import InvalidRequestError
+from authlib.oauth2.rfc6749 import OAuth2Request
+from authlib.oauth2.rfc6749.authenticate_client import _validate_client
+from authlib.oauth2.rfc6749.requests import BasicOAuth2Payload
+from authlib.oauth2.rfc9101.authorization_server import RequestURIHandler
+from authlib.oauth2.rfc9126.discovery import AuthorizationServerMetadata
+from authlib.oauth2.rfc9126.endpoint import PushedAuthorizationEndpoint
+from authlib.oauth2.rfc9126.registration import ClientMetadataClaims
+
+
+class PushedAuthorizationRequest(RequestURIHandler):
+    REQUEST_SOURCE = "pushed_authorization_request"
+
+    def __call__(self, server: AuthorizationServer):
+        super().__call__(server)
+        self.REQUEST_URI_EXTENSION.register_handler(self)
+        server.register_hook("after_get_authorization_grant", self.confirm_pushed_authorization_request)
+
+    def get_request_uri_data(self, request: OAuth2Request) -> Optional[dict]:
+        if not self._should_proceed_with_request_uri_parameter(request):
+            return None
+        return self.get_request_payload(request.payload.data["request_uri"])
+
+    def handle_request_uri_data(self, request_uri_data: dict, server: AuthorizationServer,
+                                request: OAuth2Request):
+        _validate_client(server.query_client, request.payload.client_id)
+        payload = BasicOAuth2Payload(request_uri_data)
+        request.payload = payload
+        request.source = self.REQUEST_SOURCE
+
+    def confirm_pushed_authorization_request(self, server, grant):
+        request = grant.request
+        if request.source != self.REQUEST_SOURCE:
+            client = _validate_client(server.query_client, request.payload.client_id)
+            client_metadata = self.get_client_metadata(client)
+            if client_metadata and client_metadata.require_pushed_authorization_requests:
+                raise InvalidRequestError(
+                    "Authorization requests for this client must use pushed authorization requests.",
+                    state=request.payload.state,
+                )
+
+            server_metadata = self.get_server_metadata()
+            if server_metadata and server_metadata.require_pushed_authorization_requests:
+                raise InvalidRequestError(
+                    "Authorization requests for this server must use pushed authorization requests.",
+                    state=request.payload.state,
+                )
+
+    def _should_proceed_with_request_uri_parameter(self, request: OAuth2Request):
+        if isinstance(request.endpoint, PushedAuthorizationEndpoint):
+            return False
+
+        if "request_uri" not in request.payload.data:
+            return False
+
+        return True
+
+    def get_request_payload(self, request_uri: str) -> Optional[dict]:
+        """Get the previously saved request payload by ``request_uri``
+
+        request_uri SHOULD be one-time use, so devs MAY delete immediately
+        after querying if desired. Expired request_uris MUST be handled as
+        invalid and return None.
+
+        Developers MUST implement it in subclass::
+
+            class PushedAuthorizationRequest(rfc9126.PushedAuthorizationRequest):
+                def get_request_payload(self, request_uri: str) -> Optional[dict]:
+                    return PushedAuthorizationRequestObject.get(request_uri=request_uri).payload
+
+        :param request_uri: the `request_uri` to look up
+        :return: the dict of the parameters from the initial authorization request, or None
+        """
+        raise NotImplementedError()
+
+    def get_client_metadata(self, client: ClientMixin) -> ClientMetadataClaims:
+        """Return the client metadata.
+
+        When the ``require_pushed_authorization_requests`` claim is :data:`True`,
+        the client must start the authorization process via initiating a Pushed
+        Authorization Request. If omitted, the default value is false.::
+
+            class PushedAuthorizationRequest(rfc9126.PushedAuthorizationRequest):
+                def get_client_metadata(self):
+                    return ClientMetadataClaims({
+                        "require_pushed_authorization_requests": ...,
+                    })
+
+        """
+        return ClientMetadataClaims()
+
+    def get_server_metadata(self) -> AuthorizationServerMetadata:
+        """Return server metadata which includes supported grant types,
+        response types and etc.
+
+        When the ``require_pushed_authorization_requests`` claim is :data:`True`,
+        all clients must start the authorization process via initiating a Pushed
+        Authorization Request. If omitted, the default value is false.::
+
+            class PushedAuthorizationRequest(rfc9126.PushedAuthorizationRequest):
+                def get_server_metadata(self):
+                    return AuthorizationServerMetadata({
+                        "issuer": ...,
+                        "authorization_endpoint": ...,
+                        "require_pushed_authorization_requests": ...,
+                    })
+
+        """
+        return AuthorizationServerMetadata()

--- a/authlib/oauth2/rfc9126/discovery.py
+++ b/authlib/oauth2/rfc9126/discovery.py
@@ -1,0 +1,34 @@
+from authlib.common.security import is_secure_transport
+from authlib.oauth2.rfc8414.models import _validate_boolean_value
+
+
+class AuthorizationServerMetadata(dict):
+    REGISTRY_KEYS = [
+        "pushed_authorization_request_endpoint",
+        "require_pushed_authorization_requests"
+    ]
+
+    def validate_pushed_authorization_request_endpoint(self):
+        """The URL of the pushed authorization request endpoint at which a
+        client can post an authorization request to exchange for a
+        request_uri value usable at the authorization server.
+        """
+        url = self.get("pushed_authorization_request_endpoint")
+        if url and not is_secure_transport(url):
+            raise ValueError('"pushed_authorization_request_endpoint" MUST use "https" scheme')
+
+        require_pushed_authorization_requests = self.require_pushed_authorization_requests
+        if require_pushed_authorization_requests and not url:
+            raise ValueError('"pushed_authorization_request_endpoint" is required')
+
+    def validate_require_pushed_authorization_requests(self):
+        """Boolean parameter indicating whether the authorization server
+        accepts authorization request data only via PAR. If omitted, the
+        default value is false.
+        """
+        _validate_boolean_value(self, "require_pushed_authorization_requests")
+
+    @property
+    def require_pushed_authorization_requests(self):
+        # If omitted, the default value is false.
+        return self.get("require_pushed_authorization_requests", False)

--- a/authlib/oauth2/rfc9126/endpoint.py
+++ b/authlib/oauth2/rfc9126/endpoint.py
@@ -1,0 +1,93 @@
+import logging
+import time
+from typing import Tuple
+
+from authlib.common.security import generate_token
+from authlib.consts import default_json_headers
+from authlib.oauth2.rfc6749 import AuthorizationServer
+from authlib.oauth2.rfc6749.errors import InvalidRequestError
+from authlib.oauth2.rfc6749.errors import UnauthorizedClientError
+from authlib.oauth2.rfc6749.grants import BaseGrant
+
+log = logging.getLogger(__name__)
+
+
+class PushedAuthorizationEndpoint:
+    ENDPOINT_NAME = "pushed_authorization"
+
+    #: Generated "request_uri" length
+    REQUEST_URI_PREFIX = "urn:ietf:params:oauth:request_uri"
+    REQUEST_URI_LENGTH = 48
+    REQUEST_URI_EXPIRES_IN = 60  # 1 minute
+
+    def __init__(self, server: AuthorizationServer):
+        self.server = server
+
+    def __call__(self, request):
+        return self.create_endpoint_response(request)
+
+    def create_endpoint_request(self, request):
+        return self.server.create_oauth2_request(request)
+
+    def create_endpoint_response(self, request):
+        # Must be done before `server.get_authorization_grant()` to ensure `request_uri` isn't used as part of JAR
+        if request.payload.request_uri:
+            raise InvalidRequestError(
+                "The 'request_uri' parameter MUST NOT be present in the pushed authorization request.")
+
+        grant = self.server.get_authorization_grant(request)
+        self.validate_pushed_authorization_request(grant)
+        grant.validate_authorization_request()
+
+        request_uri, expires_in = self.generate_request_uri()
+        self.save_request_payload(request.payload.data, request_uri, int(time.time() + expires_in))
+
+        response = {
+            "request_uri": request_uri,
+            "expires_in": expires_in
+        }
+
+        return 201, response, default_json_headers
+
+    def validate_pushed_authorization_request(self, grant: BaseGrant):
+        client = grant.authenticate_token_endpoint_client()
+        log.debug("Validate PAR request of %r", client)
+        if not client.check_grant_type(grant.GRANT_TYPE):
+            raise UnauthorizedClientError(
+                f"The client is not authorized to use 'grant_type={grant.GRANT_TYPE}'"
+            )
+
+    def generate_request_uri(self) -> Tuple[str, int]:
+        """The method to generate "request_uri" value for authorization code data
+        for Pushed Authorization Requests.
+
+        Developers MAY rewrite this method, or customize the code length and expires with::
+
+            class PushedAuthorizationEndpoint(rfc9126.PushedAuthorizationEndpoint):
+                REQUEST_URI_PREFIX = "urn:example"  # default is "urn:ietf:params:oauth:request_uri"
+                REQUEST_URI_LENGTH = 32  # default is 48
+                REQUEST_URI_EXPIRES_IN = 120  # default is 60
+
+        :return: a tuple containing the `request_uri` and `expires_in`
+        """
+        return f"{self.REQUEST_URI_PREFIX}:{generate_token(self.REQUEST_URI_LENGTH)}", self.REQUEST_URI_EXPIRES_IN
+
+    def save_request_payload(self, payload: dict, request_uri: str, expires_at: int):
+        """Save the request ``payload`` at ``request_uri``, with ``expires_at``.
+
+        Developers MUST implement it in subclass::
+
+            class PushedAuthorizationEndpoint(rfc9126.PushedAuthorizationEndpoint):
+                def save_request_payload(self, payload: dict, request_uri: str, expires_in: int):
+                    item = PushedAuthorizationRequestObject(
+                        request_uri=request_uri,
+                        payload=payload,
+                        expires_at=expires_at,
+                    )
+                    item.save()
+
+        :param payload: a dict of the parameters from the initial authorization request
+        :param request_uri: the generated `request_uri` to map the payload against
+        :param expires_at: when the `request_uri` expires
+        """
+        raise NotImplementedError()

--- a/authlib/oauth2/rfc9126/parameters.py
+++ b/authlib/oauth2/rfc9126/parameters.py
@@ -1,0 +1,13 @@
+from authlib.common.encoding import to_unicode
+from authlib.common.urls import add_params_to_uri
+
+
+def prepare_grant_uri(
+    uri, client_id, request_uri, **kwargs
+):
+    params = [("client_id", client_id), ("request_uri", request_uri)]
+
+    for k in kwargs:
+        if kwargs[k] is not None:
+            params.append((to_unicode(k), kwargs[k]))
+    return add_params_to_uri(uri, params)

--- a/authlib/oauth2/rfc9126/registration.py
+++ b/authlib/oauth2/rfc9126/registration.py
@@ -1,5 +1,3 @@
-from authlib.jose import BaseClaims
-from authlib.jose.errors import InvalidClaimError
 from authlib.oauth2.rfc8414.models import _validate_boolean_value
 
 
@@ -12,7 +10,7 @@ class ClientMetadataClaims(dict):
             ClientRegistrationEndpoint(
                 claims_classes=[
                     rfc7591.ClientMetadataClaims,
-                    rfc9101.ClientMetadataClaims,
+                    rfc9126.ClientMetadataClaims,
                 ]
             )
         )
@@ -21,7 +19,7 @@ class ClientMetadataClaims(dict):
             ClientRegistrationEndpoint(
                 claims_classes=[
                     rfc7591.ClientMetadataClaims,
-                    rfc9101.ClientMetadataClaims,
+                    rfc9126.ClientMetadataClaims,
                 ]
             )
         )
@@ -29,20 +27,20 @@ class ClientMetadataClaims(dict):
     """
 
     REGISTERED_CLAIMS = [
-        "require_signed_request_object",
+        "require_pushed_authorization_requests",
     ]
 
     def validate(self):
-        self.validate_require_signed_request_object()
+        self.validate_require_pushed_authorization_requests()
 
-    def validate_require_signed_request_object(self):
-        """Indicates where authorization request needs to
-        be protected as Request Object and provided through either request
-        or request_uri parameter.
+    def validate_require_pushed_authorization_requests(self):
+        """Boolean parameter indicating whether the only means of initiating
+        an authorization request the client is allowed to use is PAR. If
+        omitted, the default value is false..
         """
-        _validate_boolean_value(self, "require_signed_request_object")
+        _validate_boolean_value(self, "require_pushed_authorization_requests")
 
     @property
-    def require_signed_request_object(self):
+    def require_pushed_authorization_requests(self):
         # If omitted, the default value is false.
-        return self.get("require_signed_request_object", False)
+        return self.get("require_pushed_authorization_requests", False)


### PR DESCRIPTION
This is a WIP to request feedback early on in the approach before I clean things up, write tests, and submit an official PR.

This implements [RFC-9126: OAuth 2.0 Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)

I'm supporting ATProto (Bluesky) in my application, and their implementation requires DPoP and PAR. You can read more about their specific requirements [here](https://docs.bsky.app/docs/advanced-guides/oauth-client) for context.

This is only the client-side code at the moment, but again just looking for overall feedback before cleaning up and adding tests.

It's not particularly complicated on the client-side to support, but working it into the existing framework and maintain backwards compatibility was a bit difficult which is mostly where feedback would be welcome. Since PAR accepts all the same values at /par as would've normally been sent to /authorize I re-utilized `authorize_params` for both use-cases, and added a separate `authorize_url_params` arg specifically for parameters that need to be sent to /authorize in both PAR and non-PAR use-cases. I couldn't think of a cleaner way to do this, or even a better name (always horrible at naming things!), so suggestions are welcome.

Server support has been added as well. For saving the generated `request_uri` I added it to the AuthorizationCode, but that complicates the existing `query_authorization_code()` and `save_authorization_code()` methods since they'd need to be expanded to include the state, request_uri, and expires_in. I'm not sure how y'all have handled breaking changes like that in the past, so feedback explicitly about how you'd like to handle that would be most useful.

TODO:
* [ ] Tests
* [x] Server-side support