### PR TITLE
Add a `request` param to RFC7591 `generate_client_info` and `generate_client_secret` methods

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.6.5
+-------------
+
+**Unreleased**
+
+- RFC7591 ``generate_client_info`` and ``generate_client_secret`` take a ``request`` parameter.
+
 Version 1.6.4
 -------------
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

If the authentication token is a JWT containing data, such as the client_id to use, it should be available in the `generate_client_id` method. Thus this PR makes the `request` object available in the method.

**Does this PR introduce a breaking change?**

Yes, but it is backward compatible until 1.8.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.


---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
