### PR TITLE
Prefer `id_token_signed_response_alg` client metadata to guess algs

### DIFF
--- a/authlib/oidc/core/grants/_legacy.py
+++ b/authlib/oidc/core/grants/_legacy.py
@@ -24,20 +24,24 @@ class LegacyMixin:
         return config["key"]
 
     def get_client_algorithm(self, client):
-        """Return the algorithm for encoding ``id_token``. By default, it will
-        use ``client.id_token_signed_response_alg``, if not defined, ``RS256``
-        will be used. But you can override this method to customize the returned
-        algorithm.
+        """Return the algorithm for encoding ``id_token``.
+
+        Per `OpenID Connect Registration 1.0 Section 2
+        <https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata>`_,
+        the client metadata ``id_token_signed_response_alg`` takes precedence.
+        It falls back to ``get_jwt_config()["alg"]`` (acting as a server-wide
+        default) and finally to ``RS256``.
         """
-        # Per OpenID Connect Registration 1.0 Section 2:
-        # Use client's id_token_signed_response_alg if specified
+        if hasattr(client, "id_token_signed_response_alg") and (
+            client_alg := client.id_token_signed_response_alg
+        ):
+            return client_alg
+
         config = self._compatible_resolve_jwt_config(None, client)
         alg = config.get("alg")
         if alg:
             return alg
 
-        if hasattr(client, "id_token_signed_response_alg"):
-            return client.id_token_signed_response_alg or "RS256"
         return "RS256"
 
     def get_client_claims(self, client):

--- a/docs/upgrades/changelog.rst
+++ b/docs/upgrades/changelog.rst
@@ -6,6 +6,20 @@ Changelog
 
 Here you can see the full list of changes between each Authlib release.
 
+Version 1.8.0
+-------------
+
+**Unreleased**
+
+- **Breaking change**: the client metadata ``id_token_signed_response_alg``
+  now takes precedence over ``get_jwt_config()["alg"]`` when signing OIDC
+  ``id_token``, in line with `OpenID Connect Registration 1.0 Section 2
+  <https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata>`_.
+  ``get_jwt_config()["alg"]`` is now used as a server-wide default when the
+  client did not configure an algorithm. Override
+  ``get_client_algorithm(client)`` if you need the previous behaviour.
+  :issue:`806`
+
 Version 1.7.2
 -------------
 

--- a/tests/flask/test_oauth2/test_openid_code_grant.py
+++ b/tests/flask/test_oauth2/test_openid_code_grant.py
@@ -249,8 +249,8 @@ def test_prompt_none_not_logged(test_client, server):
 
 
 def test_client_metadata_custom_alg(test_client, server, client, db, app):
-    """If the client metadata 'id_token_signed_response_alg' is defined,
-    it should be used to sign id_tokens."""
+    """The client metadata 'id_token_signed_response_alg' must take
+    precedence over the server-wide ``get_jwt_config()`` ``alg``."""
     register_oidc_code_grant(
         server,
     )
@@ -265,7 +265,7 @@ def test_client_metadata_custom_alg(test_client, server, client, db, app):
     )
     db.session.add(client)
     db.session.commit()
-    del app.config["OAUTH2_JWT_ALG"]
+    assert app.config["OAUTH2_JWT_ALG"] == "HS256"
 
     rv = test_client.post(
         "/oauth/authorize",
@@ -303,6 +303,54 @@ def test_client_metadata_custom_alg(test_client, server, client, db, app):
     )
     claims.validate()
     assert claims.header["alg"] == "HS384"
+
+
+def test_jwt_config_alg_fallback(test_client, server, client, db, app):
+    """When the client has no ``id_token_signed_response_alg`` defined,
+    ``get_jwt_config()["alg"]`` is used as the server-wide default."""
+    register_oidc_code_grant(server)
+    client.set_client_metadata(
+        {
+            "redirect_uris": ["https://client.test"],
+            "scope": "openid profile address",
+            "response_types": ["code"],
+            "grant_types": ["authorization_code"],
+        }
+    )
+    db.session.add(client)
+    db.session.commit()
+    app.config["OAUTH2_JWT_ALG"] = "HS384"
+
+    rv = test_client.post(
+        "/oauth/authorize",
+        data={
+            "response_type": "code",
+            "client_id": "client-id",
+            "state": "bar",
+            "scope": "openid profile",
+            "redirect_uri": "https://client.test",
+            "user_id": "1",
+        },
+    )
+    params = dict(url_decode(urlparse.urlparse(rv.location).query))
+    code = params["code"]
+    headers = create_basic_header("client-id", "client-secret")
+    rv = test_client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "redirect_uri": "https://client.test",
+            "code": code,
+        },
+        headers=headers,
+    )
+    resp = json.loads(rv.data)
+    token = jwt.decode(
+        resp["id_token"],
+        key=OctKey.import_key("secret"),
+        algorithms=["HS384"],
+    )
+    assert token.header["alg"] == "HS384"
 
 
 def test_client_metadata_alg_none(test_client, server, app, db, client):

--- a/tests/flask/test_oauth2/test_openid_implict_grant.py
+++ b/tests/flask/test_oauth2/test_openid_implict_grant.py
@@ -231,7 +231,7 @@ def test_client_metadata_custom_alg(test_client, app, db, client):
     db.session.add(client)
     db.session.commit()
 
-    app.config["OAUTH2_JWT_ALG"] = None
+    app.config["OAUTH2_JWT_ALG"] = "HS256"
     rv = test_client.post(
         "/oauth/authorize",
         data={


### PR DESCRIPTION
Fix #806 

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [x] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.
- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.
