### PR TITLE
fix: accept falsy-but-present essential claims in _validate_essential_claims

### DIFF
--- a/authlib/jose/rfc7519/claims.py
+++ b/authlib/jose/rfc7519/claims.py
@@ -56,7 +56,7 @@ class BaseClaims(dict):
             if self.options[k].get("essential"):
                 if k not in self:
                     raise MissingClaimError(k)
-                elif not self.get(k):
+                elif self.get(k) is None:
                     raise InvalidClaimError(k)
 
     def _validate_claim_value(self, claim_name):

--- a/tests/jose/test_jwt.py
+++ b/tests/jose/test_jwt.py
@@ -81,6 +81,16 @@ def test_validate_expected_issuer_received_None():
         claims.validate()
 
 
+def test_validate_essential_claim_with_falsy_numeric_value():
+    # Essential claims with falsy but valid values (e.g. nbf=0) must not
+    # raise InvalidClaimError — only a missing or None claim should.
+    id_token = jwt.encode({"alg": "HS256"}, {"nbf": 0}, "k")
+    claims_options = {"nbf": {"essential": True}}
+    claims = jwt.decode(id_token, "k", claims_options=claims_options)
+    # nbf=0 is present and valid; essential check must pass
+    claims._validate_essential_claims()
+
+
 def test_validate_aud():
     id_token = jwt.encode({"alg": "HS256"}, {"aud": "foo"}, "k")
     claims_options = {"aud": {"essential": True, "value": "foo"}}


### PR DESCRIPTION
## Summary

`_validate_essential_claims` uses `not self.get(k)` to detect invalid essential claim values, but this incorrectly rejects any falsy value — including `0`, `""`, and `False` — even when the claim **is present** with a legitimately falsy payload value.

The most impactful case is numeric time claims (`nbf`, `exp`, `iat`) set to `0` (Unix epoch). A JWT with `nbf: 0` means "valid from the Unix epoch", which is a perfectly valid token, but the current code raises `InvalidClaimError("nbf")` when that claim is marked `essential`.

**Before (buggy):**
```python
elif not self.get(k):     # treats 0, "", False as "invalid"
    raise InvalidClaimError(k)
```

**After (fixed):**
```python
elif self.get(k) is None: # only None (truly absent or explicitly None) is invalid
    raise InvalidClaimError(k)
```

This preserves the existing behaviour for `None`-valued claims (the existing test `test_validate_expected_issuer_received_None` still passes) while correctly accepting numeric `0` and other falsy-but-present values.

## Reproducer

```python
from authlib.jose.rfc7519.claims import JWTClaims
from authlib.jose.errors import InvalidClaimError

payload = {"nbf": 0}
options = {"nbf": {"essential": True}}
claims = JWTClaims(payload, {}, options)
claims._validate_essential_claims()  # raises InvalidClaimError before this fix
```

## Test plan

- Added `test_validate_essential_claim_with_falsy_numeric_value` to `tests/jose/test_jwt.py`.
- All 24 JWT tests pass (`pytest tests/jose/test_jwt.py`).

This pull request was prepared with the assistance of AI, under my direction and review.