### PR TITLE
fix(oauth): save device credential with authenticated client id

### DIFF
--- a/authlib/oauth2/rfc8628/endpoint.py
+++ b/authlib/oauth2/rfc8628/endpoint.py
@@ -115,7 +115,7 @@ class DeviceAuthorizationEndpoint:
         }
 
         self.save_device_credential(
-            request.payload.client_id, request.payload.scope, data
+            request.client.get_client_id(), request.payload.scope, data
         )
         return 200, data, default_json_headers
 

--- a/tests/flask/test_oauth2/test_device_code_grant.py
+++ b/tests/flask/test_oauth2/test_device_code_grant.py
@@ -12,6 +12,7 @@ from authlib.oauth2.rfc8628 import DeviceCredentialDict
 from .models import Client
 from .models import User
 from .models import db
+from .oauth2_server import create_basic_header
 
 device_credentials = {
     "valid-device": {
@@ -72,12 +73,15 @@ class DeviceCodeGrant(_DeviceCodeGrant):
         return False
 
 
+saved_credentials = []
+
+
 class DeviceAuthorizationEndpoint(_DeviceAuthorizationEndpoint):
     def get_verification_uri(self):
         return "https://resource.test/activate"
 
     def save_device_credential(self, client_id, scope, data):
-        pass
+        saved_credentials.append({"client_id": client_id, "scope": scope})
 
 
 @pytest.fixture(autouse=True)
@@ -237,6 +241,30 @@ def test_missing_client_id(test_client):
     assert rv.status_code == 401
     resp = json.loads(rv.data)
     assert resp["error"] == "invalid_client"
+
+
+def test_client_secret_basic_saves_authenticated_client_id(test_client, db, client):
+    # When the client authenticates with HTTP Basic, its id is in the
+    # Authorization header rather than the form body, so the saved credential
+    # must come from the authenticated client, not request.payload.client_id.
+    client.set_client_metadata(
+        {
+            "scope": "profile",
+            "grant_types": [DeviceCodeGrant.GRANT_TYPE],
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+    )
+    db.session.add(client)
+    db.session.commit()
+
+    saved_credentials.clear()
+    rv = test_client.post(
+        "/device_authorize",
+        data={"scope": "profile"},
+        headers=create_basic_header("client-id", "client-secret"),
+    )
+    assert rv.status_code == 200
+    assert saved_credentials[-1]["client_id"] == "client-id"
 
 
 def test_create_authorization_response(test_client):


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix for #798. `DeviceAuthorizationEndpoint.create_endpoint_response` saves the device credential with `request.payload.client_id`, but that only holds the id when the client sends it in the form body. A client using `client_secret_basic` puts its id in the Authorization header, so `payload.client_id` is `None` and the credential ends up stored with a null client_id even though the request authenticated fine. Since `authenticate_client` runs just above and sets `request.client`, I switched the save call to `request.client.get_client_id()`, which is the id we actually authenticated. Two of us hit this in the issue, and there's a test in the thread that matches.

I added a flask test that authenticates the device endpoint over HTTP Basic and checks the saved credential carries the real client_id; it fails on `main` (saves `None`) and passes with the change, and the rest of the oauth2 suite still passes.

**Does this PR introduce a breaking change?**

No.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [ ] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.

fix #798 