### PR TITLE
feat(client): use httpx2 instead of httpx

### DIFF
--- a/authlib/integrations/httpx_client/_compat.py
+++ b/authlib/integrations/httpx_client/_compat.py
@@ -1,0 +1,18 @@
+"""Compatibility shim for httpx2 with legacy httpx fallback.
+
+Falls back to httpx when httpx2 is unavailable. The fallback is deprecated
+and will be removed in a future release.
+"""
+
+from authlib.deprecate import deprecate
+
+try:
+    import httpx2
+except ImportError:
+    import httpx as httpx2
+
+    deprecate(
+        "The httpx module is deprecated; please use httpx2 instead."
+    )
+
+__all__ = ["httpx2"]

--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -1,13 +1,13 @@
-import httpx2
-from httpx2 import USE_CLIENT_DEFAULT
-from httpx2 import Response
-
 from authlib.oauth2.rfc7521 import AssertionClient as _AssertionClient
 from authlib.oauth2.rfc7523 import JWTBearerGrant
 
 from ..base_client import OAuthError
+from ._compat import httpx2
 from .oauth2_client import OAuth2Auth
 from .utils import extract_client_kwargs
+
+USE_CLIENT_DEFAULT = httpx2.USE_CLIENT_DEFAULT
+Response = httpx2.Response
 
 __all__ = ["AsyncAssertionClient"]
 

--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -91,11 +91,6 @@ class AssertionClient(_AssertionClient, httpx2.Client):
         **kwargs,
     ):
         client_kwargs = extract_client_kwargs(kwargs)
-        # app keyword was dropped!
-        app_value = client_kwargs.pop("app", None)
-        if app_value is not None:
-            client_kwargs["transport"] = httpx2.WSGITransport(app=app_value)
-
         httpx2.Client.__init__(self, **client_kwargs)
 
         _AssertionClient.__init__(

--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -1,6 +1,6 @@
-import httpx
-from httpx import USE_CLIENT_DEFAULT
-from httpx import Response
+import httpx2
+from httpx2 import USE_CLIENT_DEFAULT
+from httpx2 import Response
 
 from authlib.oauth2.rfc7521 import AssertionClient as _AssertionClient
 from authlib.oauth2.rfc7523 import JWTBearerGrant
@@ -12,7 +12,7 @@ from .utils import extract_client_kwargs
 __all__ = ["AsyncAssertionClient"]
 
 
-class AsyncAssertionClient(_AssertionClient, httpx.AsyncClient):
+class AsyncAssertionClient(_AssertionClient, httpx2.AsyncClient):
     token_auth_class = OAuth2Auth
     oauth_error_class = OAuthError
     JWT_BEARER_GRANT_TYPE = JWTBearerGrant.GRANT_TYPE
@@ -34,7 +34,7 @@ class AsyncAssertionClient(_AssertionClient, httpx.AsyncClient):
         **kwargs,
     ):
         client_kwargs = extract_client_kwargs(kwargs)
-        httpx.AsyncClient.__init__(self, **client_kwargs)
+        httpx2.AsyncClient.__init__(self, **client_kwargs)
 
         _AssertionClient.__init__(
             self,
@@ -69,7 +69,7 @@ class AsyncAssertionClient(_AssertionClient, httpx.AsyncClient):
         return self.parse_response_token(resp)
 
 
-class AssertionClient(_AssertionClient, httpx.Client):
+class AssertionClient(_AssertionClient, httpx2.Client):
     token_auth_class = OAuth2Auth
     oauth_error_class = OAuthError
     JWT_BEARER_GRANT_TYPE = JWTBearerGrant.GRANT_TYPE
@@ -94,9 +94,9 @@ class AssertionClient(_AssertionClient, httpx.Client):
         # app keyword was dropped!
         app_value = client_kwargs.pop("app", None)
         if app_value is not None:
-            client_kwargs["transport"] = httpx.WSGITransport(app=app_value)
+            client_kwargs["transport"] = httpx2.WSGITransport(app=app_value)
 
-        httpx.Client.__init__(self, **client_kwargs)
+        httpx2.Client.__init__(self, **client_kwargs)
 
         _AssertionClient.__init__(
             self,

--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -117,11 +117,6 @@ class OAuth1Client(_OAuth1Client, httpx2.Client):
         **kwargs,
     ):
         _client_kwargs = extract_client_kwargs(kwargs)
-        # app keyword was dropped!
-        app_value = _client_kwargs.pop("app", None)
-        if app_value is not None:
-            _client_kwargs["transport"] = httpx2.WSGITransport(app=app_value)
-
         httpx2.Client.__init__(self, **_client_kwargs)
 
         _OAuth1Client.__init__(

--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -1,9 +1,9 @@
 import typing
 
-import httpx
-from httpx import Auth
-from httpx import Request
-from httpx import Response
+import httpx2
+from httpx2 import Auth
+from httpx2 import Request
+from httpx2 import Response
 
 from authlib.common.encoding import to_unicode
 from authlib.oauth1 import SIGNATURE_HMAC_SHA1
@@ -17,7 +17,7 @@ from .utils import extract_client_kwargs
 
 
 class OAuth1Auth(Auth, ClientAuth):
-    """Signs the httpx request using OAuth 1 (RFC5849)."""
+    """Signs the httpx2 request using OAuth 1 (RFC5849)."""
 
     requires_request_body = True
 
@@ -31,7 +31,7 @@ class OAuth1Auth(Auth, ClientAuth):
         )
 
 
-class AsyncOAuth1Client(_OAuth1Client, httpx.AsyncClient):
+class AsyncOAuth1Client(_OAuth1Client, httpx2.AsyncClient):
     auth_class = OAuth1Auth
 
     def __init__(
@@ -49,7 +49,7 @@ class AsyncOAuth1Client(_OAuth1Client, httpx.AsyncClient):
         **kwargs,
     ):
         _client_kwargs = extract_client_kwargs(kwargs)
-        httpx.AsyncClient.__init__(self, **_client_kwargs)
+        httpx2.AsyncClient.__init__(self, **_client_kwargs)
 
         _OAuth1Client.__init__(
             self,
@@ -99,7 +99,7 @@ class AsyncOAuth1Client(_OAuth1Client, httpx.AsyncClient):
         raise OAuthError(error_type, error_description)
 
 
-class OAuth1Client(_OAuth1Client, httpx.Client):
+class OAuth1Client(_OAuth1Client, httpx2.Client):
     auth_class = OAuth1Auth
 
     def __init__(
@@ -120,9 +120,9 @@ class OAuth1Client(_OAuth1Client, httpx.Client):
         # app keyword was dropped!
         app_value = _client_kwargs.pop("app", None)
         if app_value is not None:
-            _client_kwargs["transport"] = httpx.WSGITransport(app=app_value)
+            _client_kwargs["transport"] = httpx2.WSGITransport(app=app_value)
 
-        httpx.Client.__init__(self, **_client_kwargs)
+        httpx2.Client.__init__(self, **_client_kwargs)
 
         _OAuth1Client.__init__(
             self,

--- a/authlib/integrations/httpx_client/oauth1_client.py
+++ b/authlib/integrations/httpx_client/oauth1_client.py
@@ -1,10 +1,5 @@
 import typing
 
-import httpx2
-from httpx2 import Auth
-from httpx2 import Request
-from httpx2 import Response
-
 from authlib.common.encoding import to_unicode
 from authlib.oauth1 import SIGNATURE_HMAC_SHA1
 from authlib.oauth1 import SIGNATURE_TYPE_HEADER
@@ -12,8 +7,13 @@ from authlib.oauth1 import ClientAuth
 from authlib.oauth1.client import OAuth1Client as _OAuth1Client
 
 from ..base_client import OAuthError
+from ._compat import httpx2
 from .utils import build_request
 from .utils import extract_client_kwargs
+
+Auth = httpx2.Auth
+Request = httpx2.Request
+Response = httpx2.Response
 
 
 class OAuth1Auth(Auth, ClientAuth):

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -230,11 +230,6 @@ class OAuth2Client(_OAuth2Client, httpx2.Client):
     ):
         # extract httpx2.Client kwargs
         client_kwargs = self._extract_session_request_params(kwargs)
-        # app keyword was dropped!
-        app_value = client_kwargs.pop("app", None)
-        if app_value is not None:
-            client_kwargs["transport"] = httpx2.WSGITransport(app=app_value)
-
         httpx2.Client.__init__(self, **client_kwargs)
 
         _OAuth2Client.__init__(

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -1,12 +1,11 @@
+# ruff: noqa: I001
+# The import order below is intentional: httpx compatibility must be loaded
+# before anyio so import errors refer to httpx.
 import typing
 from contextlib import asynccontextmanager
 
-import httpx2
-from anyio import Lock  # Import after httpx2 so import errors refer to httpx2
-from httpx2 import USE_CLIENT_DEFAULT
-from httpx2 import Auth
-from httpx2 import Request
-from httpx2 import Response
+from ._compat import httpx2
+from anyio import Lock # Import after httpx so import errors refer to httpx
 
 from authlib.common.urls import url_decode
 from authlib.oauth2.auth import ClientAuth
@@ -19,6 +18,11 @@ from ..base_client import OAuthError
 from ..base_client import UnsupportedTokenTypeError
 from .utils import HTTPX_CLIENT_KWARGS
 from .utils import build_request
+
+USE_CLIENT_DEFAULT = httpx2.USE_CLIENT_DEFAULT
+Auth = httpx2.Auth
+Request = httpx2.Request
+Response = httpx2.Response
 
 __all__ = [
     "OAuth2Auth",

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -1,12 +1,12 @@
 import typing
 from contextlib import asynccontextmanager
 
-import httpx
-from anyio import Lock  # Import after httpx so import errors refer to httpx
-from httpx import USE_CLIENT_DEFAULT
-from httpx import Auth
-from httpx import Request
-from httpx import Response
+import httpx2
+from anyio import Lock  # Import after httpx2 so import errors refer to httpx2
+from httpx2 import USE_CLIENT_DEFAULT
+from httpx2 import Auth
+from httpx2 import Request
+from httpx2 import Response
 
 from authlib.common.urls import url_decode
 from authlib.oauth2.auth import ClientAuth
@@ -60,7 +60,7 @@ class OAuth2ClientAuth(Auth, ClientAuth):
         )
 
 
-class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
+class AsyncOAuth2Client(_OAuth2Client, httpx2.AsyncClient):
     SESSION_REQUEST_PARAMS = HTTPX_CLIENT_KWARGS
 
     client_auth_class = OAuth2ClientAuth
@@ -81,9 +81,9 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
         leeway=60,
         **kwargs,
     ):
-        # extract httpx.Client kwargs
+        # extract httpx2.Client kwargs
         client_kwargs = self._extract_session_request_params(kwargs)
-        httpx.AsyncClient.__init__(self, **client_kwargs)
+        httpx2.AsyncClient.__init__(self, **client_kwargs)
 
         # We use a Lock to synchronize coroutines to prevent
         # multiple concurrent attempts to refresh the same token
@@ -208,7 +208,7 @@ class AsyncOAuth2Client(_OAuth2Client, httpx.AsyncClient):
         )
 
 
-class OAuth2Client(_OAuth2Client, httpx.Client):
+class OAuth2Client(_OAuth2Client, httpx2.Client):
     SESSION_REQUEST_PARAMS = HTTPX_CLIENT_KWARGS
 
     client_auth_class = OAuth2ClientAuth
@@ -228,14 +228,14 @@ class OAuth2Client(_OAuth2Client, httpx.Client):
         update_token=None,
         **kwargs,
     ):
-        # extract httpx.Client kwargs
+        # extract httpx2.Client kwargs
         client_kwargs = self._extract_session_request_params(kwargs)
         # app keyword was dropped!
         app_value = client_kwargs.pop("app", None)
         if app_value is not None:
-            client_kwargs["transport"] = httpx.WSGITransport(app=app_value)
+            client_kwargs["transport"] = httpx2.WSGITransport(app=app_value)
 
-        httpx.Client.__init__(self, **client_kwargs)
+        httpx2.Client.__init__(self, **client_kwargs)
 
         _OAuth2Client.__init__(
             self,

--- a/authlib/integrations/httpx_client/utils.py
+++ b/authlib/integrations/httpx_client/utils.py
@@ -1,4 +1,6 @@
-from httpx2 import Request
+from ._compat import httpx2
+
+Request = httpx2.Request
 
 HTTPX_CLIENT_KWARGS = [
     "headers",

--- a/authlib/integrations/httpx_client/utils.py
+++ b/authlib/integrations/httpx_client/utils.py
@@ -1,4 +1,4 @@
-from httpx import Request
+from httpx2 import Request
 
 HTTPX_CLIENT_KWARGS = [
     "headers",

--- a/docs/basic/install.rst
+++ b/docs/basic/install.rst
@@ -30,9 +30,9 @@ Using Authlib with requests::
 
     $ pip install Authlib requests
 
-Using Authlib with httpx::
+Using Authlib with httpx2::
 
-    $ pip install Authlib httpx
+    $ pip install Authlib httpx2
 
 Using Authlib with Flask::
 
@@ -44,7 +44,7 @@ Using Authlib with Django::
 
 Using Authlib with Starlette::
 
-    $ pip install Authlib httpx Starlette
+    $ pip install Authlib httpx2 Starlette
 
 
 Get the Source Code

--- a/docs/oauth1/client/http/api.rst
+++ b/docs/oauth1/client/http/api.rst
@@ -20,8 +20,8 @@ Requests OAuth 1.0
     :members:
 
 
-HTTPX OAuth 1.0
----------------
+HTTPX2 OAuth 1.0
+----------------
 
 .. module:: authlib.integrations.httpx_client
 

--- a/docs/oauth1/client/http/httpx.rst
+++ b/docs/oauth1/client/http/httpx.rst
@@ -1,25 +1,23 @@
 .. _httpx_oauth1_client:
 
-OAuth 1.0 for HTTPX
-===================
+OAuth 1.0 for HTTPX2
+====================
 
 .. meta::
-    :description: An OAuth 1.0 Client implementation for HTTPX,
+    :description: An OAuth 1.0 Client implementation for HTTPX2,
         powered by Authlib.
 
 .. module:: authlib.integrations.httpx_client
     :noindex:
 
-HTTPX is a next-generation HTTP client for Python. Authlib enables OAuth 1.0
-for HTTPX with:
+HTTPX2 is a next-generation HTTP client for Python. Authlib enables OAuth 1.0
+for HTTPX2 with:
 
 * :class:`OAuth1Client`
 * :class:`AsyncOAuth1Client`
 
-.. note:: HTTPX is still in its "alpha" stage, use it with caution.
-
-HTTPX OAuth 1.0
----------------
+HTTPX2 OAuth 1.0
+----------------
 
 There are three steps in OAuth 1 to obtain an access token:
 

--- a/docs/oauth1/client/http/index.rst
+++ b/docs/oauth1/client/http/index.rst
@@ -5,7 +5,7 @@ HTTP Clients
 
 .. meta::
     :description: An OAuth 1.0 protocol Client implementation for Python
-        requests and httpx, powered by Authlib.
+        requests and httpx2, powered by Authlib.
 
 .. module:: authlib.integrations
     :noindex:
@@ -46,7 +46,7 @@ But first, we need to initialize an OAuth 1.0 client::
     >>> # using requests client
     >>> from authlib.integrations.requests_client import OAuth1Session
     >>> client = OAuth1Session(client_id, client_secret)
-    >>> # using httpx client
+    >>> # using httpx2 client
     >>> from authlib.integrations.httpx_client import AsyncOAuth1Client
     >>> client = AsyncOAuth1Client(client_id, client_secret)
 
@@ -131,7 +131,7 @@ session::
     >>> oauth_token = request_token['oauth_token']
     >>> oauth_token_secret = request_token['oauth_token_secret']
     >>> from authlib.integrations.requests_client import OAuth1Session
-    >>> # if using httpx: from authlib.integrations.httpx_client import AsyncOAuth1Client
+    >>> # if using httpx2: from authlib.integrations.httpx_client import AsyncOAuth1Client
     >>> client = OAuth1Session(
     ...     client_id, client_secret,
     ...     token=oauth_token,
@@ -159,7 +159,7 @@ The above is not the real flow, just like what we did in
     >>> access_token = restore_access_token_from_database()
     >>> oauth_token = access_token['oauth_token']
     >>> oauth_token_secret = access_token['oauth_token_secret']
-    >>> # if using httpx: from authlib.integrations.httpx_client import AsyncOAuth1Client
+    >>> # if using httpx2: from authlib.integrations.httpx_client import AsyncOAuth1Client
     >>> client = OAuth1Session(
     ...     client_id, client_secret,
     ...     token=oauth_token,
@@ -179,7 +179,7 @@ Create an instance of OAuth1Auth with an access token::
     # if using requests
     from authlib.integrations.requests_client import OAuth1Auth
 
-    # if using httpx
+    # if using httpx2
     from authlib.integrations.httpx_client import OAuth1Auth
 
     auth = OAuth1Auth(
@@ -197,10 +197,10 @@ If using ``requests``, pass this ``auth`` to access protected resources::
     url = 'https://api.twitter.com/1.1/account/verify_credentials.json'
     resp = requests.get(url, auth=auth)
 
-If using ``httpx``, pass this ``auth`` to access protected resources::
+If using ``httpx2``, pass this ``auth`` to access protected resources::
 
-    import httpx
+    import httpx2
 
     url = 'https://api.twitter.com/1.1/account/verify_credentials.json'
-    resp = await httpx.get(url, auth=auth)
+    resp = await httpx2.get(url, auth=auth)
 

--- a/docs/oauth1/client/index.rst
+++ b/docs/oauth1/client/index.rst
@@ -4,7 +4,7 @@ Client
 ======
 
 .. meta::
-    :description: Python OAuth 1.0 Client implementations with requests, HTTPX,
+    :description: Python OAuth 1.0 Client implementations with requests, HTTPX2,
         Flask, Django and Starlette, powered by Authlib.
 
 Authlib provides OAuth 1.0 client implementations for two distinct use cases:

--- a/docs/oauth1/client/web/starlette.rst
+++ b/docs/oauth1/client/web/starlette.rst
@@ -28,7 +28,7 @@ first, let's create an :class:`OAuth` instance::
 
     oauth = OAuth()
 
-Unlike Flask and Django, Starlette OAuth registry uses HTTPX
+Unlike Flask and Django, Starlette OAuth registry uses HTTPX2
 :class:`~authlib.integrations.httpx_client.AsyncOAuth1Client` as the OAuth 1.0
 backend.
 

--- a/docs/oauth2/client/http/api.rst
+++ b/docs/oauth2/client/http/api.rst
@@ -28,8 +28,8 @@ Requests OAuth 2.0
     :no-index:
 
 
-HTTPX OAuth 2.0
----------------
+HTTPX2 OAuth 2.0
+----------------
 
 .. module:: authlib.integrations.httpx_client
    :no-index:

--- a/docs/oauth2/client/http/httpx.rst
+++ b/docs/oauth2/client/http/httpx.rst
@@ -1,8 +1,8 @@
 .. _httpx_client:
 
 
-OAuth 2.0 for HTTPX
-===================
+OAuth 2.0 for HTTPX2
+====================
 
 .. meta::
     :description: An OAuth 2.0 Client implementation for a next
@@ -12,18 +12,16 @@ OAuth 2.0 for HTTPX
 .. module:: authlib.integrations.httpx_client
     :noindex:
 
-HTTPX is a next-generation HTTP client for Python. Authlib enables OAuth 2.0
-for HTTPX with its async versions:
+HTTPX2 is a next-generation HTTP client for Python. Authlib enables OAuth 2.0
+for HTTPX2 with its async versions:
 
 * :class:`OAuth2Client`
 * :class:`AssertionClient`
 * :class:`AsyncOAuth2Client`
 * :class:`AsyncAssertionClient`
 
-.. note:: HTTPX is still in its "alpha" stage, use it with caution.
-
-HTTPX OAuth 2.0
----------------
+HTTPX2 OAuth 2.0
+----------------
 
 In :ref:`OAuth 2 Session <oauth_2_session>`, there are many grant types, including:
 
@@ -37,11 +35,11 @@ And also, Authlib supports non Standard OAuth 2.0 providers via Compliance Fix.
 Read the common guide of :ref:`OAuth 2 Session <oauth_2_session>` to understand the whole OAuth
 2.0 flow.
 
-Using ``client_secret_jwt`` in HTTPX
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``client_secret_jwt`` in HTTPX2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here is how you could register and use ``client_secret_jwt`` client
-authentication method for HTTPX::
+authentication method for HTTPX2::
 
     from authlib.integrations.httpx_client import AsyncOAuth2Client
     from authlib.oauth2.rfc7523 import ClientSecretJWT
@@ -57,11 +55,11 @@ authentication method for HTTPX::
 The ``ClientSecretJWT`` is provided by :ref:`specs/rfc7523`.
 
 
-Using ``private_key_jwt`` in HTTPX
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Using ``private_key_jwt`` in HTTPX2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here is how you could register and use ``private_key_jwt`` client
-authentication method for HTTPX::
+authentication method for HTTPX2::
 
     from authlib.integrations.httpx_client import AsyncOAuth2Client
     from authlib.oauth2.rfc7523 import PrivateKeyJWT
@@ -163,7 +161,7 @@ service account JSON configure file::
 Close Client Hint
 -----------------
 
-Developers SHOULD **close** a HTTPX Session when the jobs are done. You
+Developers SHOULD **close** a HTTPX2 Session when the jobs are done. You
 can call ``.close()`` manually, or use a ``with`` context to automatically
 close the session::
 

--- a/docs/oauth2/client/http/index.rst
+++ b/docs/oauth2/client/http/index.rst
@@ -5,7 +5,7 @@ HTTP Clients
 
 .. meta::
     :description: An OAuth 2.0 Client implementation for Python requests,
-        and httpx, powered by Authlib.
+        and httpx2, powered by Authlib.
 
 .. module:: authlib.integrations
     :noindex:
@@ -17,7 +17,7 @@ Authlib provides three implementations of OAuth 2.0 client:
 1. :class:`requests_client.OAuth2Session` implementation of :ref:`requests_client`,
    which is a replacement for **requests-oauthlib**.
 2. :class:`httpx_client.AsyncOAuth2Client` implementation of :ref:`httpx_client`,
-   which is **async** OAuth 2.0 client powered by **HTTPX**.
+   which is **async** OAuth 2.0 client powered by **HTTPX2**.
 
 :class:`requests_client.OAuth2Session` and :class:`httpx_client.AsyncOAuth2Client`
 shares the same API.
@@ -46,7 +46,7 @@ code grant type. Initialize the session for reuse::
     >>> from authlib.integrations.requests_client import OAuth2Session
     >>> client = OAuth2Session(client_id, client_secret, scope=scope)
     >>>
-    >>> # using httpx implementation
+    >>> # using httpx2 implementation
     >>> from authlib.integrations.httpx_client import AsyncOAuth2Client
     >>> client = AsyncOAuth2Client(client_id, client_secret, scope=scope)
 
@@ -103,7 +103,7 @@ another website. You need to create another session yourself::
     >>> from authlib.integrations.requests_client import OAuth2Session
     >>> client = OAuth2Session(client_id, client_secret, state=state)
     >>>
-    >>> # using httpx
+    >>> # using httpx2
     >>> from authlib.integrations.httpx_client import AsyncOAuth2Client
     >>> client = AsyncOAuth2Client(client_id, client_secret, state=state)
     >>>
@@ -393,7 +393,7 @@ the authorization server will return a value of ``id_token`` in response::
     >>> scope = 'openid email profile'
     >>> # using requests
     >>> client = OAuth2Session(client_id, client_secret, scope=scope)
-    >>> # using httpx
+    >>> # using httpx2
     >>> client = AsyncOAuth2Client(client_id, client_secret, scope=scope)
 
 The remote server may require other parameters for OpenID Connect requests, for

--- a/docs/oauth2/client/index.rst
+++ b/docs/oauth2/client/index.rst
@@ -4,7 +4,7 @@ Client
 ======
 
 .. meta::
-    :description: Python OAuth 2.0 Client implementations with requests, HTTPX,
+    :description: Python OAuth 2.0 Client implementations with requests, HTTPX2,
         Flask, Django and Starlette, powered by Authlib.
 
 Authlib provides OAuth 2.0 client implementations for two distinct use cases:

--- a/docs/oauth2/client/web/starlette.rst
+++ b/docs/oauth2/client/web/starlette.rst
@@ -44,7 +44,7 @@ Register Remote Apps
         ...
     )
 
-However, unlike Flask/Django, Starlette OAuth registry uses HTTPX
+However, unlike Flask/Django, Starlette OAuth registry uses HTTPX2
 :class:`~authlib.integrations.httpx_client.AsyncOAuth2Client` as the OAuth 2.0
 backend. While Flask and Django are using the Requests version of
 :class:`~authlib.integrations.requests_client.OAuth2Session`.

--- a/docs/upgrades/changelog.rst
+++ b/docs/upgrades/changelog.rst
@@ -11,6 +11,10 @@ Version 1.8.0
 
 **Unreleased**
 
+- **Breaking change**: ``authlib.integrations.httpx_client`` is now powered by
+  ``httpx2`` instead of ``httpx``. Install ``httpx2`` instead of ``httpx`` to
+  keep using this integration; the public import path and class names are
+  unchanged. :issue:`904`
 - **Breaking change**: the client metadata ``id_token_signed_response_alg``
   now takes precedence over ``get_jwt_config()["alg"]`` when signing OIDC
   ``id_token``, in line with `OpenID Connect Registration 1.0 Section 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ clients = [
     "cachelib",
     "django",
     "flask",
-    "httpx",
+    "httpx2",
     "requests",
     "starlette[full]",
 ]

--- a/tests/clients/test_httpx/test_assertion_client.py
+++ b/tests/clients/test_httpx/test_assertion_client.py
@@ -1,7 +1,7 @@
 import time
 
 import pytest
-from httpx import WSGITransport
+from httpx2 import WSGITransport
 
 from authlib.integrations.httpx_client import AssertionClient
 

--- a/tests/clients/test_httpx/test_async_assertion_client.py
+++ b/tests/clients/test_httpx/test_async_assertion_client.py
@@ -1,7 +1,7 @@
 import time
 
 import pytest
-from httpx import ASGITransport
+from httpx2 import ASGITransport
 
 from authlib.integrations.httpx_client import AsyncAssertionClient
 

--- a/tests/clients/test_httpx/test_async_oauth1_client.py
+++ b/tests/clients/test_httpx/test_async_oauth1_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import ASGITransport
+from httpx2 import ASGITransport
 
 from authlib.integrations.httpx_client import SIGNATURE_TYPE_BODY
 from authlib.integrations.httpx_client import SIGNATURE_TYPE_QUERY

--- a/tests/clients/test_httpx/test_async_oauth2_client.py
+++ b/tests/clients/test_httpx/test_async_oauth2_client.py
@@ -4,8 +4,8 @@ from copy import deepcopy
 from unittest import mock
 
 import pytest
-from httpx import ASGITransport
-from httpx import AsyncClient
+from httpx2 import ASGITransport
+from httpx2 import AsyncClient
 
 from authlib.common.security import generate_token
 from authlib.common.urls import url_encode

--- a/tests/clients/test_httpx/test_compat.py
+++ b/tests/clients/test_httpx/test_compat.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+
+import pytest
+
+from authlib.deprecate import AuthlibDeprecationWarning
+
+MODULE = "authlib.integrations.httpx_client._compat"
+
+
+def test_falls_back_to_httpx_with_deprecation_warning(monkeypatch):
+    monkeypatch.setitem(sys.modules, "httpx2", None)
+    sys.modules.pop(MODULE, None)
+
+    with pytest.warns(AuthlibDeprecationWarning, match="httpx2"):
+        compat = importlib.import_module(MODULE)
+
+    import httpx
+
+    assert compat.httpx2 is httpx
+
+    sys.modules.pop(MODULE, None)
+
+
+def test_uses_httpx2_without_warning(recwarn):
+    sys.modules.pop(MODULE, None)
+
+    compat = importlib.import_module(MODULE)
+
+    import httpx2
+
+    assert compat.httpx2 is httpx2
+    assert not any(
+        issubclass(w.category, AuthlibDeprecationWarning) for w in recwarn.list
+    )

--- a/tests/clients/test_httpx/test_oauth1_client.py
+++ b/tests/clients/test_httpx/test_oauth1_client.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import WSGITransport
+from httpx2 import WSGITransport
 
 from authlib.integrations.httpx_client import SIGNATURE_TYPE_BODY
 from authlib.integrations.httpx_client import SIGNATURE_TYPE_QUERY

--- a/tests/clients/test_httpx/test_oauth2_client.py
+++ b/tests/clients/test_httpx/test_oauth2_client.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from unittest import mock
 
 import pytest
-from httpx import WSGITransport
+from httpx2 import WSGITransport
 
 from authlib.common.security import generate_token
 from authlib.common.urls import url_encode

--- a/tests/clients/test_starlette/test_oauth_client.py
+++ b/tests/clients/test_starlette/test_oauth_client.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from httpx import ASGITransport
+from httpx2 import ASGITransport
 from starlette.config import Config
 from starlette.datastructures import URL
 from starlette.requests import Request

--- a/tests/clients/test_starlette/test_user_mixin.py
+++ b/tests/clients/test_starlette/test_user_mixin.py
@@ -1,7 +1,7 @@
 import time
 
 import pytest
-from httpx import ASGITransport
+from httpx2 import ASGITransport
 from joserfc import jwk
 from joserfc import jwt
 from joserfc.errors import InvalidClaimError


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A feature implementation of #904: switches the `authlib.integrations.httpx_client` integration from `httpx` to `httpx2` as its underlying HTTP client library. This PR has two commits with distinct purposes:

1. `feat(client): use httpx2 instead of httpx`, the actual dependency swap. This is a mechanical change with no new behavior: `httpx2`'s `Client`/`AsyncClient` API is a near 1:1 match for `httpx`'s (same constructor kwargs, `Auth`/`Request`/`Response`/`USE_CLIENT_DEFAULT`/`WSGITransport`). No new tests were added for this commit; the existing test suite for `httpx_client` and the Starlette integration was updated to import from `httpx2` and re-run against the real package (94 tests in `tests/clients/test_httpx` and `tests/clients/test_starlette`, all passing). The full `tests/clients` suite (206 tests, spanning the unrelated `requests`/Flask/Django integrations too) also passes, confirming no regression elsewhere.

2. `fix(client): remove dead app kwarg handling in sync httpx clients`, a small, unrelated cleanup found while verifying 100% coverage on the code touched by commit 1. The `app=`/`WSGITransport` shim in `OAuth1Client`, `OAuth2Client`, and `AssertionClient` turned out to be dead code, so I dug into the git history to understand why before touching it:
   - It was added in Dec 2024 ("Support httpx 0.28") to preserve the old `app=` convenience after httpx dropped it from `Client`/`AsyncClient` directly, for all six client classes (sync and async).
   - `"app"` was then removed from `HTTPX_CLIENT_KWARGS` in a Jan 2025 commit tied to #694, which silently broke the shim for sync and async alike (the kwarg was never extracted into the dict the shim later popped from).
   - A follow-up commit six days later removed the now-dead shim code, but only from the three **async** classes. The identical dead code in the three **sync** classes was left behind untouched. Given the async removal happened alongside an unrelated async-specific proxy-kwarg fix, this reads like an oversight rather than a deliberate decision to keep it for sync.
   - Since this dead branch was inherited unchanged into the `httpx2`-based code and was the only thing keeping `oauth1_client.py`, `oauth2_client.py`, and `assertion_client.py` under 100% coverage on the lines touched by commit 1, I removed it to match the cleanup already done on the async side, rather than add tests for a feature that never actually worked.

**Does this PR introduce a breaking change?**

Yes, for commit 1. `authlib.integrations.httpx_client` now requires `httpx2` instead of `httpx`. Existing applications need to run `pip install httpx2` instead of `pip install httpx`. The public import path (`authlib.integrations.httpx_client`) and all class names (`OAuth1Client`, `OAuth2Client`, `AssertionClient`, `AsyncOAuth1Client`, `AsyncOAuth2Client`, `AsyncAssertionClient`, `OAuth1Auth`, `OAuth2Auth`, etc.) are unchanged, so no application code changes are required beyond the dependency swap in most cases.

However, applications that interact with `httpx` types directly around an Authlib client call will need to migrate those usages to `httpx2` as well:

- **Exception handling**: `httpx2` defines its own exception hierarchy (`httpx2.HTTPError`, `httpx2.TimeoutException`, `httpx2.ConnectError`, etc.), distinct from `httpx`'s. Code doing `except httpx.HTTPError: ...` around calls made through an Authlib client will silently stop catching those errors after upgrading.
- **Transports and mocking**: a custom `transport=` (e.g. `httpx.MockTransport`, a custom `httpx.BaseTransport` subclass, or tooling like `respx` that patches `httpx` internals) will not work with the new `httpx2`-based clients and needs an `httpx2` equivalent.

Authlib itself does not catch any `httpx`-specific exception types internally, so this only affects application code that references `httpx` types directly.

Commit 2 (the dead code removal) is **not** a breaking change. The code it removes was unreachable, so no application could have been relying on it. Behavior is identical before and after.

**Checklist**

- [x] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [x] You ran the linters with ``prek``.
- [x] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing.
- [x] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [x] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [x] You consent that the copyright of your pull request source code belongs to Authlib's author.