### PR TITLE
fix: Always raise_for_status when parsing response token

### DIFF
--- a/authlib/oauth2/client.py
+++ b/authlib/oauth2/client.py
@@ -412,8 +412,7 @@ class OAuth2Client:
         self.compliance_hook[hook_type].add(hook)
 
     def parse_response_token(self, resp):
-        if resp.status_code >= 500:
-            resp.raise_for_status()
+        _ = resp.raise_for_status()
 
         token = resp.json()
         if "error" in token:


### PR DESCRIPTION
<!--
> DO NOT SEND ANY SECURITY FIX HERE. Please read "Security Reporting" section
> on README.
-->

**What kind of change does this PR introduce?**

When checking a token response, one should always call `response.raise_for_status()`, as both `requests` and `httpx` versions of that function only raise an actual error if the response had one.
And especially only raising one for status code 500+ is wrong, because 400+ are also errors.
For example, if the token endpoint does not exist, the code base currently does not properly handle this situation.

**Does this PR introduce a breaking change?**

No

**Checklist**

- [X] The commits follow the [conventional commits](https://www.conventionalcommits.org) specification.
- [X] You ran the linters with ``prek``.
- [ ] You wrote unit test to demonstrate the bug you are fixing, or to stress the feature you are bringing. -> No unit test necessary for this I think?
- [X] You reached 100% of code coverage on the code you edited, without abusive use of `pragma: no cover`
- [X] If this PR is about a new feature, or a behavior change, you have updated the documentation accordingly.

---

- [X] You consent that the copyright of your pull request source code belongs to Authlib's author.
