### PR TITLE
fix(oauth1): correct protocol name in InsecureTransportError description

### DIFF
--- a/authlib/oauth1/rfc5849/errors.py
+++ b/authlib/oauth1/rfc5849/errors.py
@@ -26,7 +26,7 @@ class OAuth1Error(AuthlibHTTPError):
 
 class InsecureTransportError(OAuth1Error):
     error = "insecure_transport"
-    description = "OAuth 2 MUST utilize https."
+    description = "OAuth 1 MUST utilize https."
 
     @classmethod
     def check(cls, uri):


### PR DESCRIPTION
Noticed this while reading through #627 — the OAuth1 InsecureTransportError
carries the description string from its OAuth2 counterpart, so its message
reads "OAuth 2 MUST utilize https." An OAuth 1.0a client hitting an http://
endpoint gets told it must use HTTPS for a protocol it isn't even using.

It's in authlib/oauth1/rfc5849/errors.py line 29. The same string is in
authlib/oauth2/rfc6749/errors.py line 59, which is where it belongs — this
only touches the OAuth1 copy, so the OAuth2 one is untouched. Nothing asserts
the old text anywhere, and it's only a description, so behaviour is the same.

tests/core and tests/flask/test_oauth1 both pass, ruff is clean.

#627 also asks about dropping the transport check from OAuth1 altogether.
That one's a behaviour change so I left it alone — happy to look at it
separately if you want it, but this bit seemed worth fixing on its own
either way.
