### PR TITLE
AsyncOpenIDMixin.parse_id_token: return None when id_token is absent, matching the sync client

### DIFF
--- a/authlib/integrations/base_client/async_openid.py
+++ b/authlib/integrations/base_client/async_openid.py
@@ -42,6 +42,9 @@ class AsyncOpenIDMixin:
         self, token, nonce, claims_options=None, claims_cls=None, leeway=120
     ):
         """Return an instance of UserInfo from token's ``id_token``."""
+        if "id_token" not in token:
+            return None
+
         claims_params = dict(
             nonce=nonce,
             client_id=self.client_id,

--- a/tests/clients/test_starlette/test_user_mixin.py
+++ b/tests/clients/test_starlette/test_user_mixin.py
@@ -63,7 +63,6 @@ async def test_parse_id_token():
         "at_hash": create_half_hash(token["access_token"], "HS256").decode("utf-8"),
     }
     id_token = jwt.encode({"alg": "HS256"}, claims, secret_key)
-    token["id_token"] = id_token
 
     oauth = OAuth()
     client = oauth.register(
@@ -75,6 +74,9 @@ async def test_parse_id_token():
         issuer="https://provider.test",
         id_token_signing_alg_values_supported=["HS256", "RS256"],
     )
+    assert await client.parse_id_token(token, nonce="n") is None
+
+    token["id_token"] = id_token
     user = await client.parse_id_token(token, nonce="n")
     assert user.sub == "123"
 
@@ -112,11 +114,9 @@ async def test_runtime_error_fetch_jwks_uri():
         issuer="https://provider.test",
         id_token_signing_alg_values_supported=["HS256"],
     )
-    req_scope = {"type": "http", "session": {"_dev_authlib_nonce_": "n"}}
-    req = Request(req_scope)
     token["id_token"] = id_token
     with pytest.raises(RuntimeError):
-        await client.parse_id_token(req, token)
+        await client.parse_id_token(token, nonce="n")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`OpenIDMixin.parse_id_token` starts with a guard the async version doesn't have:

```python
if "id_token" not in token:
    return None
```

So the same call returns `None` on the sync client and raises `KeyError: 'id_token'` on the async one. The first commit adds it.

The sync test suite already asserted the `None` case (`test_flask/test_user_mixin.py`), and the async suite never did, which is how the two drifted apart. That assertion is mirrored across.

The second commit changes a test. That needs explaining.

Adding the guard means a token without an `id_token` now returns early, before `load_server_metadata()`. That exposed `test_runtime_error_fetch_jwks_uri`, which calls:

```python
await client.parse_id_token(req, token)
```

The signature is `(token, nonce)`. That call uses the old `(request, token)` order, and it is the only one of eight sites that still does. The test passed because the `RuntimeError` was raised before anything read the misplaced arguments, so the stale call never mattered. With the guard in place the request object goes in as `token`, has no `id_token`, and returns `None` before the error can happen.

I changed that call to `(token, nonce="n")` so it matches the rest, and dropped the now-unused request object. It asserts the same `RuntimeError` path, now with a valid token.

`test_starlette/test_user_mixin.py` goes from 4 passing with one relying on that stale call to 4 passing without it. The sync suite is untouched and still passes.

I ran the starlette and flask client suites. Not the django ones, which need dependencies I don't have installed.
