### PR TITLE
feat: let ResourceProtector take a token_validator in __init__

### DIFF
--- a/authlib/oauth2/rfc6749/resource_protector.py
+++ b/authlib/oauth2/rfc6749/resource_protector.py
@@ -84,10 +84,12 @@ class TokenValidator:
 
 
 class ResourceProtector:
-    def __init__(self):
+    def __init__(self, token_validator: TokenValidator | None = None):
         self._token_validators = {}
         self._default_realm = None
         self._default_auth_type = None
+        if token_validator is not None:
+            self.register_token_validator(token_validator)
 
     def register_token_validator(self, validator: TokenValidator):
         """Register a token validator for a given Authorization type.

--- a/docs/oauth2/resource-server/django.rst
+++ b/docs/oauth2/resource-server/django.rst
@@ -12,8 +12,7 @@ server. Here is the way to protect your users' resources in Django::
     from authlib.integrations.django_oauth2 import ResourceProtector, BearerTokenValidator
     from django.http import JsonResponse
 
-    require_oauth = ResourceProtector()
-    require_oauth.register_token_validator(BearerTokenValidator(OAuth2Token))
+    require_oauth = ResourceProtector(token_validator=BearerTokenValidator(OAuth2Token))
 
     @require_oauth('profile')
     def user_profile(request):

--- a/docs/oauth2/resource-server/flask.rst
+++ b/docs/oauth2/resource-server/flask.rst
@@ -17,9 +17,14 @@ server. Authlib offers a **decorator** to protect your API endpoints::
         def authenticate_token(self, token_string):
             return Token.query.filter_by(access_token=token_string).first()
 
-    require_oauth = ResourceProtector()
-
     # only bearer token is supported currently
+    require_oauth = ResourceProtector(token_validator=MyBearerTokenValidator())
+
+You can also register the validator afterwards, which is useful if you need
+to register more than one (for instance, to support both bearer tokens and
+another token type)::
+
+    require_oauth = ResourceProtector()
     require_oauth.register_token_validator(MyBearerTokenValidator())
 
 When the resource server has no access to the ``Token`` model (database), and

--- a/docs/upgrades/changelog.rst
+++ b/docs/upgrades/changelog.rst
@@ -31,6 +31,12 @@ Version 1.8.0
   validation, as in ``https://client.test@attacker.test/cb``. URIs that
   ``urlparse`` refuses to parse, such as ``http://[not-an-ip]/``, are also
   rejected instead of raising an unhandled ``ValueError``.
+- ``ResourceProtector`` now accepts an optional ``token_validator`` argument,
+  so ``ResourceProtector(token_validator=MyBearerTokenValidator())`` registers
+  it immediately instead of requiring a separate
+  ``register_token_validator()`` call. ``register_token_validator()`` is
+  unchanged and still the way to register additional validators (e.g. more
+  than one token type). :issue:`603`
 - Cast the ``sub`` claim to a string in the RFC 9068 and RFC 7523
   ``JWTBearerTokenGenerator``, as required by RFC 7519 Section 4.1.2.
   ``joserfc`` 1.7.3 started validating this claim and rejected the previously

--- a/tests/core/test_oauth2/test_resource_protector.py
+++ b/tests/core/test_oauth2/test_resource_protector.py
@@ -1,0 +1,56 @@
+import pytest
+
+from authlib.oauth2.rfc6749.errors import UnsupportedTokenTypeError
+from authlib.oauth2.rfc6749.resource_protector import ResourceProtector
+from authlib.oauth2.rfc6750 import BearerTokenValidator
+
+
+class _StubBearerTokenValidator(BearerTokenValidator):
+    def authenticate_token(self, token_string):
+        return None
+
+
+def test_no_validator_behaves_as_before():
+    protector = ResourceProtector()
+    with pytest.raises(UnsupportedTokenTypeError):
+        protector.get_token_validator("bearer")
+
+
+def test_token_validator_registered_via_constructor():
+    validator = _StubBearerTokenValidator(realm="dev")
+    protector = ResourceProtector(token_validator=validator)
+    assert protector.get_token_validator("bearer") is validator
+    assert protector._default_realm == "dev"
+    assert protector._default_auth_type == "bearer"
+
+
+def test_constructor_and_register_token_validator_are_equivalent():
+    via_constructor = ResourceProtector(token_validator=_StubBearerTokenValidator())
+
+    via_register = ResourceProtector()
+    via_register.register_token_validator(_StubBearerTokenValidator())
+
+    assert via_constructor._default_auth_type == via_register._default_auth_type
+    assert via_constructor._default_realm == via_register._default_realm
+    assert list(via_constructor._token_validators) == list(
+        via_register._token_validators
+    )
+
+
+def test_additional_validators_can_still_be_registered_after_constructor():
+    bearer = _StubBearerTokenValidator()
+    protector = ResourceProtector(token_validator=bearer)
+
+    class _MacTokenValidator(BearerTokenValidator):
+        TOKEN_TYPE = "mac"
+
+        def authenticate_token(self, token_string):
+            return None
+
+    mac = _MacTokenValidator()
+    protector.register_token_validator(mac)
+
+    assert protector.get_token_validator("bearer") is bearer
+    assert protector.get_token_validator("mac") is mac
+    # The constructor-passed validator is still the one that set the default.
+    assert protector._default_auth_type == "bearer"


### PR DESCRIPTION
Closes #603. That issue's been open a while with no response, so wanted to flag up front: I haven't gotten explicit sign-off on this direction from a maintainer — happy to adjust or drop this if the API isn't wanted as-is.

## What this does

`ResourceProtector()` always needed a follow-up `.register_token_validator(...)` call before it was usable, even for the common single-validator case. This adds an optional `token_validator` kwarg to `__init__` that just calls `register_token_validator()` internally:

```python
# before
require_oauth = ResourceProtector()
require_oauth.register_token_validator(MyBearerTokenValidator())

# now, equivalently
require_oauth = ResourceProtector(token_validator=MyBearerTokenValidator())
```

`register_token_validator()` itself is untouched — it's still how you add more than one validator (e.g. supporting a second token type alongside bearer).

## Scope

Flask's and Django's `ResourceProtector` subclasses don't override `__init__`, so they inherit this for free — no changes needed in either integration module. I checked OAuth1's `ResourceProtector` too: it's a completely separate class (`query_client`/`query_token`/`exists_nonce` callbacks, no `register_token_validator` concept at all), so this doesn't apply there and I left it alone.

## Changes

- `authlib/oauth2/rfc6749/resource_protector.py` — the `__init__` change
- `tests/core/test_oauth2/test_resource_protector.py` — new file (there wasn't a dedicated unit test for `ResourceProtector` itself, only Flask/Django integration-level coverage). Covers: no-validator behavior is unchanged, the constructor path and `register_token_validator()` end up in the same state, and additional validators can still be registered afterward.
- `docs/oauth2/resource-server/flask.rst`, `docs/oauth2/resource-server/django.rst` — updated the getting-started examples to the new form
- `docs/upgrades/changelog.rst` — entry under Unreleased

## Testing

```
pytest tests/core/ tests/flask/ tests/django/
```
599 passed, 2 skipped (pre-existing, unrelated) — ran against the full suite, not just the new test file, to make sure nothing else assumes `ResourceProtector.__init__` takes no arguments. `ruff check` and `ruff format --check` both clean.