### PR TITLE
Accept httpx URL objects on OAuth client requests

### DIFF
--- a/authlib/integrations/httpx_client/assertion_client.py
+++ b/authlib/integrations/httpx_client/assertion_client.py
@@ -4,6 +4,7 @@ from authlib.oauth2.rfc7523 import JWTBearerGrant
 from ..base_client import OAuthError
 from ._compat import httpx2
 from .oauth2_client import OAuth2Auth
+from .utils import coerce_url
 from .utils import extract_client_kwargs
 
 USE_CLIENT_DEFAULT = httpx2.USE_CLIENT_DEFAULT
@@ -61,7 +62,7 @@ class AsyncAssertionClient(_AssertionClient, httpx2.AsyncClient):
                 await self.refresh_token()
 
             auth = self.token_auth
-        return await super().request(method, url, auth=auth, **kwargs)
+        return await super().request(method, coerce_url(url), auth=auth, **kwargs)
 
     async def _refresh_token(self, data):
         resp = await self.request(
@@ -120,4 +121,4 @@ class AssertionClient(_AssertionClient, httpx2.Client):
                 self.refresh_token()
 
             auth = self.token_auth
-        return super().request(method, url, auth=auth, **kwargs)
+        return super().request(method, coerce_url(url), auth=auth, **kwargs)

--- a/authlib/integrations/httpx_client/oauth2_client.py
+++ b/authlib/integrations/httpx_client/oauth2_client.py
@@ -18,6 +18,7 @@ from ..base_client import OAuthError
 from ..base_client import UnsupportedTokenTypeError
 from .utils import HTTPX_CLIENT_KWARGS
 from .utils import build_request
+from .utils import coerce_url
 
 USE_CLIENT_DEFAULT = httpx2.USE_CLIENT_DEFAULT
 Auth = httpx2.Auth
@@ -120,7 +121,7 @@ class AsyncOAuth2Client(_OAuth2Client, httpx2.AsyncClient):
 
             auth = self.token_auth
 
-        return await super().request(method, url, auth=auth, **kwargs)
+        return await super().request(method, coerce_url(url), auth=auth, **kwargs)
 
     @asynccontextmanager
     async def stream(
@@ -134,7 +135,7 @@ class AsyncOAuth2Client(_OAuth2Client, httpx2.AsyncClient):
 
             auth = self.token_auth
 
-        async with super().stream(method, url, auth=auth, **kwargs) as resp:
+        async with super().stream(method, coerce_url(url), auth=auth, **kwargs) as resp:
             yield resp
 
     async def ensure_active_token(self, token):
@@ -267,7 +268,7 @@ class OAuth2Client(_OAuth2Client, httpx2.Client):
 
             auth = self.token_auth
 
-        return super().request(method, url, auth=auth, **kwargs)
+        return super().request(method, coerce_url(url), auth=auth, **kwargs)
 
     def stream(
         self, method, url, withhold_token=False, auth=USE_CLIENT_DEFAULT, **kwargs
@@ -281,4 +282,4 @@ class OAuth2Client(_OAuth2Client, httpx2.Client):
 
             auth = self.token_auth
 
-        return super().stream(method, url, auth=auth, **kwargs)
+        return super().stream(method, coerce_url(url), auth=auth, **kwargs)

--- a/authlib/integrations/httpx_client/utils.py
+++ b/authlib/integrations/httpx_client/utils.py
@@ -44,3 +44,9 @@ def build_request(url, headers, body, initial_request: Request) -> Request:
         updated_request.extensions = initial_request.extensions
 
     return updated_request
+
+
+def coerce_url(url):
+    if isinstance(url, str):
+        return url
+    return str(url)

--- a/tests/clients/test_httpx/test_async_oauth2_client.py
+++ b/tests/clients/test_httpx/test_async_oauth2_client.py
@@ -62,15 +62,16 @@ async def test_add_token_get_request(assert_func, token_placement):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "assert_func, token_placement",
-    [
-        (assert_token_in_header, "header"),
-        (assert_token_in_body, "body"),
-        (assert_token_in_uri, "uri"),
-    ],
-)
-async def test_add_token_to_streaming_request(assert_func, token_placement):
+async def test_get_accepts_url_object():
+    from httpx2 import URL
+
+    transport = ASGITransport(AsyncMockDispatch({"a": "a"}))
+    async with AsyncOAuth2Client(
+        "foo", token=default_token, transport=transport
+    ) as client:
+        resp = await client.get(URL("https://provider.test"))
+
+    assert resp.json()["a"] == "a"
     transport = ASGITransport(AsyncMockDispatch({"a": "a"}, assert_func=assert_func))
     async with AsyncOAuth2Client(
         "foo", token=default_token, token_placement=token_placement, transport=transport

--- a/tests/clients/test_httpx/test_async_oauth2_client.py
+++ b/tests/clients/test_httpx/test_async_oauth2_client.py
@@ -72,15 +72,6 @@ async def test_get_accepts_url_object():
         resp = await client.get(URL("https://provider.test"))
 
     assert resp.json()["a"] == "a"
-    transport = ASGITransport(AsyncMockDispatch({"a": "a"}, assert_func=assert_func))
-    async with AsyncOAuth2Client(
-        "foo", token=default_token, token_placement=token_placement, transport=transport
-    ) as client:
-        async with client.stream("GET", "https://provider.test") as stream:
-            await stream.aread()
-            data = stream.json()
-
-    assert data["a"] == "a"
 
 
 @pytest.mark.parametrize(

--- a/tests/clients/test_httpx/test_async_oauth2_client.py
+++ b/tests/clients/test_httpx/test_async_oauth2_client.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from unittest import mock
 
 import pytest
+from httpx2 import URL
 from httpx2 import ASGITransport
 from httpx2 import AsyncClient
 
@@ -62,16 +63,44 @@ async def test_add_token_get_request(assert_func, token_placement):
 
 
 @pytest.mark.asyncio
-async def test_get_accepts_url_object():
-    from httpx2 import URL
-
-    transport = ASGITransport(AsyncMockDispatch({"a": "a"}))
+@pytest.mark.parametrize(
+    "assert_func, token_placement",
+    [
+        (assert_token_in_header, "header"),
+        (assert_token_in_body, "body"),
+        (assert_token_in_uri, "uri"),
+    ],
+)
+async def test_add_token_to_streaming_request(assert_func, token_placement):
+    transport = ASGITransport(AsyncMockDispatch({"a": "a"}, assert_func=assert_func))
     async with AsyncOAuth2Client(
-        "foo", token=default_token, transport=transport
+        "foo", token=default_token, token_placement=token_placement, transport=transport
+    ) as client:
+        async with client.stream("GET", "https://provider.test") as stream:
+            await stream.aread()
+            data = stream.json()
+
+    assert data["a"] == "a"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "assert_func, token_placement",
+    [
+        (assert_token_in_header, "header"),
+        (assert_token_in_body, "body"),
+        (assert_token_in_uri, "uri"),
+    ],
+)
+async def test_add_token_with_url_object(assert_func, token_placement):
+    transport = ASGITransport(AsyncMockDispatch({"a": "a"}, assert_func=assert_func))
+    async with AsyncOAuth2Client(
+        "foo", token=default_token, token_placement=token_placement, transport=transport
     ) as client:
         resp = await client.get(URL("https://provider.test"))
 
-    assert resp.json()["a"] == "a"
+    data = resp.json()
+    assert data["a"] == "a"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
httpx/httpx2 pass URL instances into get/request/stream. The Authlib wrappers forwarded those objects through as-is and they broke in places that expected a str.

str() them at the request/stream boundary on the async and sync OAuth2 and assertion clients.

Fixes #931